### PR TITLE
refactor: remove global side effects (roadmap 1.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,373 @@
+# Poniard — Improvement Roadmap
+
+## Positioning
+
+Poniard's defensible value proposition is not "answer quick questions" — every
+model-comparison library does that. The actual differentiators are:
+
+- Type-aware preprocessing (`PoniardPreprocessor`) with cardinality-driven
+  encoder selection, datetime expansion, and a `ColumnTransformer` that is
+  inspectable and editable.
+- The Dummy baseline + `wrt_dummy` ratio as a built-in sanity check.
+- A same-object loop: comparison → tune → ensemble → error analysis, all over
+  the same cross-validated fold structure.
+- **Error analysis** (`ErrorAnalyzer`) as a first-class concern. Most
+  competitors stop at a leaderboard; Poniard keeps going into *where and why*
+  the models fail. This is the heart of the library's identity and the bit that
+  needs the most investment.
+- The preprocessor and pipelines are plain sklearn objects the user owns and
+  can export — Poniard is scaffolding you delete.
+
+The pitch to sharpen: **"A transparent, sklearn-native model-comparison
+workbench, type-aware preprocessing included, that hands you back a normal
+sklearn pipeline when you're done — and tells you where your models are
+wrong."**
+
+---
+
+## Priority 1 — Correctness and trust (fix before anything else)
+
+These are bug-class issues that silently erode trust in the parts the library
+is proudest of.
+
+### 1.1 Remove global side effects
+
+Every implicit global mutation must go. These are the things that get a library
+quietly abandoned after one bad afternoon.
+
+- `poniard/__init__.py` calls `sklearn.set_config(transform_output="pandas")`
+  at import time. This affects every other sklearn transformer in the host
+  program. Replace with a local `with sklearn.config_context(...)` block
+  around the code that actually needs pandas output, or set
+  `transform_output="pandas"` only on the `PoniardPreprocessor`'s own
+  transformer instances. Importing poniard must have no effect on global state.
+- `PoniardPlotFactory.__init__` mutates `plotly.io.templates.default` and
+  `plotly.express.defaults.color_discrete_sequence`. Replace by applying the
+  template/colors **per figure** (pass `template=...` to each `px.*` call) and
+  never touching globals.
+- `PoniardPreprocessor(cache_transformations=True)` writes to
+  `transformation_cache/` in the current working directory (hardcoded relative
+  path) and never cleans up. Use `tempfile.TemporaryDirectory` bound to the
+  instance, or accept a path and document it; never default to silently
+  creating files in CWD.
+
+### 1.2 Fix bugs in differentiated modules
+
+#### `LinearSVR` / `SVR` grid mismatch
+`PoniardRegressor._default_estimators` ships `LinearSVR`, but the predefined
+grid in `poniard/utils/hyperparameters.py` is keyed `"SVR`. Calling
+`tune_estimator("LinearSVR", ...)` with no grid raises `NotImplementedError`.
+
+Resolution (see also 3.1): the default hparam grids are being deleted entirely,
+which eliminates this mismatch. Confirm `LinearSVR` still fits cleanly with no
+default grid behavior to break.
+
+#### `ErrorAnalyzer.analyze_features` bugs
+Two correctness issues in the most differentiated method of the most
+differentiated module:
+
+1. **Positional-vs-name index mismatch.** `most_important_idx` holds column
+   *positional* indices (from `importances_mean.argsort()[::-1][:n]`), but the
+   loop iterates `for i, feature in enumerate(X.columns)` and checks
+   `i in most_important_idx or feature in features`. When `features` is None,
+   this sets `most_important_idx=[]` and `features=X.columns`, so the
+   `i in most_important_idx` check is dead. When `estimator_name` is given,
+   `features=[]` and `most_important_idx` is positional — correct in that
+   branch but inconsistent. Unify on **one** representation (positional
+   indices) and never compare a positional int to a column name.
+
+2. **`_train_test_split_from_cv()` called without `X, y`.**
+   `analyze_features` calls `self._poniard._train_test_split_from_cv()` with
+   no arguments, but that method requires `X` and `y`. This would `NameError`
+   in the `estimator_name` branch. Pass `X` and `y` through from the
+   `analyze_features` call site — or, if `ErrorAnalyzer` was constructed via
+   `from_poniard`, read `X`/`y` off the bound poniard estimator (and require
+   they be stored there).
+
+### 1.3 Replace `id()`-based fitted-pipeline tracking
+
+`PoniardBaseEstimator.fit` tracks which pipelines have been cross-validated by
+storing their Python `id()` in `_fitted_pipeline_ids`. Old pipeline objects can
+be garbage-collected and new ones reuse the id, causing `fit` to silently skip
+newly added estimators.
+
+Replace with a set of **pipeline names** (the keys of `self.pipelines`). Names
+are already the user-facing identity and are stable across
+`add_preprocessing_step` / `reassign_types` rebuilds (which should invalidate
+the fit set by getting new names or by the rebuild clearing the set).
+
+---
+
+## Priority 2 — Architecture and surface
+
+### 2.1 Eliminate `setup`/`fit` duplication (keep the two-step UX)
+
+The user-facing contract stays: `setup(X, y)` runs type inference and builds
+pipelines so the user can introspect (`feature_types`, `preprocessor`,
+`pipelines`, `metrics`) and adjust (`reassign_types`,
+`add_preprocessing_step`, `add/remove_estimators`) **before** any fitting. Then
+`fit(X, y)` cross-validates.
+
+The current problem is ~40 lines of duplicated logic (input conversion,
+`target_info`, metrics resolution, preprocessor build, info printing, pipeline
+build, CV build) appearing verbatim in both methods.
+
+Resolution: extract the shared "configure" logic into a private method (e.g.
+`_configure(X, y, show_info)`) that **both** `setup` and `fit` call. `setup`
+calls it and returns. `fit` calls it (idempotent — re-running it with the same
+inputs is a no-op, re-running after `reassign_types` rebuilds the pipelines as
+it already does) and then proceeds to cross-validate. The two-method UX and
+introspection flow are preserved; the duplicate code is gone.
+
+### 2.2 Promote `get_estimator` to the headline exporter
+
+`get_estimator(name, include_preprocessor=True, X=None, y=None, retrain=True)`
+is already the "give me a normal sklearn pipeline I own" escape hatch. Push it
+to the front of the README and the docstring:
+
+- Document it as the supported way to leave Poniard.
+- Guarantee the returned object is a plain `sklearn.pipeline.Pipeline` (or bare
+  estimator when `include_preprocessor=False`) with no poniard references.
+- Add a test that round-trips: build a poniard estimator, `get_estimator(...,
+  retrain=True)`, then `pickle.dumps` the result and confirm it loads without
+  poniard installed (run in a subprocess with `PYTHONPATH` stripped) — this is
+  the real definition of "you can delete poniard when you're done."
+
+### 2.3 Remove default hyperparameter grids entirely
+
+`poniard/utils/hyperparameters.py` ships predefined grids for the default
+estimators plus XGBoost (which isn't a dependency). Problems:
+
+- The `LinearSVR`/`SVR` mismatch above.
+- Defaults encode opinions about what to tune, which varies wildly by dataset.
+- XGBoost/CatBoost/LightGBM grids are present for a library the user installed
+  themselves; the user knows their booster's GPU/n_thread situation better
+  than poniard does.
+
+Resolution: **delete `GRID` and the `grid=None` → look-up-`GRID` path in
+`tune_estimator`.** Require the user to pass `grid=...` explicitly. This makes
+`tune_estimator` a thin convenience wrapper around sklearn's search classes on
+top of a poniard pipeline, with no surprise opinionated defaults.
+
+If a user wants the old behavior, they can keep a `hyperparameters.py`-style
+dict in their own project. (If we ever want to bring back opinionated grids,
+ship them as a *separate* optional module, not as default behavior.)
+
+### 2.4 Reduce the public method surface
+
+Commit to a small, observable-tested core. Cut the operator overloads —
+`__add__` / `__sub__` / `__getitem__` — they save no time over
+`add_estimators` / `remove_estimators` and `pipelines[name]`, and every method
+is a documentation and testing burden. Keep:
+
+- `setup`, `fit`, `get_results`
+- `predict`, `predict_proba`, `decision_function` (drop `predict_all`? keep
+  only if used by plots/error analysis)
+- `add_estimators`, `remove_estimators`, `get_estimator`
+- `reassign_types`, `add_preprocessing_step`
+- `tune_estimator`, `build_ensemble`
+- `get_predictions_similarity`
+
+Everything else is an internal implementation detail.
+
+### 2.5 Tighten the default estimator lists
+
+Defaults are opinions; pick strong ones. `SVC(kernel="linear",
+probability=True)` is slow and rarely competitive on real tabular data —
+people sit through a tqdm bar and wonder why it's there. Consider:
+
+Classification:
+- `LogisticRegression(max_iter=5000)`
+- `RandomForestClassifier()`
+- `HistGradientBoostingClassifier()`
+
+Regression:
+- `LinearRegression()`
+- `ElasticNet()`
+- `RandomForestRegressor()`
+- `HistGradientBoostingRegressor()`
+
+Plus the auto-added Dummy. `KNeighbors`, `DecisionTree`, `GaussianNB`,
+`LinearSVR` can stay if you want breadth, but `SVC(kernel="linear")` should
+go. Keep the dummy at all costs — it's the `wrt_dummy` value prop.
+
+---
+
+## Priority 3 — Make error analysis a headline
+
+`ErrorAnalyzer` is the module most competitors don't have, and the one most
+aligned with how you actually do ML. It needs investment, not deletion.
+
+### 3.1 Test coverage
+
+`ErrorAnalyzer` currently has **zero tests.** This is the scariest gap in the
+library. Add tests covering:
+
+- `from_poniard` construction.
+- `rank_errors` for binary, multiclass, multilabel, continuous, and
+  continuous-multioutput targets — assert the right error metric is selected
+  and the returned DataFrame has the right index and columns.
+- `merge_errors` aggregation: `mean_error`, `freq`, per-row estimator lists.
+- `analyze_target` for classification (error vs target distribution) and
+  regression (binned).
+- `analyze_features`:
+  - without `estimator_name` (just `features=X.columns`),
+  - with `estimator_name` and `n_features` (positional-index path),
+  - the bug-fixes from 1.2 verified by assertions on the selected features.
+- Round-trip: `from_poniard` → `rank_errors` → `merge_errors` →
+  `analyze_target` → `analyze_features` on a synthetic dataset where the
+  expected error region is known.
+
+### 3.2 Fix the integration bugs (1.2) and make `from_poniard` carry data
+
+`from_poniard(poniard, estimator_names)` should capture `X` and `y` from the
+bound poniard estimator so `analyze_features` and `analyze_target` can be
+called without re-passing them. Currently `_train_test_split_from_cv()` is
+called without `X, y` and would `NameError`. Either:
+
+- store `X`/`y` on `ErrorAnalyzer` at `from_poniard` time (requires the poniard
+  estimator to also store them — it receive them in `setup`/`fit` and keep
+  refs), or
+- change `analyze_*` to require `X`/`y` explicitly and stop pretending the
+  no-arg path works.
+
+Storing `X`/`y` on the poniard estimator is also needed for `predict` /
+`predict_proba` / `get_estimator(retrain=True)` to be callable without
+re-passing data, and is needed for pickling (see 4.1). Prefer that.
+
+### 3.3 Documentation and discoverability
+
+- Add an `ErrorAnalyzer` section to the README.
+- Add an example notebook covering the full error-analysis workflow
+  (rank errors → merge → analyze by target → analyze by feature → interpret).
+- Rename private `_full_estimator_analysis` in `PoniardPlotFactory` — it's a
+  user-facing dashboard; either surface it publicly or document it as
+  internal. Right now it's the best plot in the library and nobody can find it.
+
+### 3.4 Plotting tests
+
+`PoniardPlotFactory` has zero tests. Add smoke tests that instantiate it via
+`poniard[plot]` and assert each method returns a `plotly.graph_objects.Figure`
+without raising, on both classification and regression poniard estimators.
+These don't need to assert on figure contents — just that the call paths don't
+explode. The integration with `_experiment_results` and
+`_get_or_compute_prediction` is fragile and only exercised when a user clicks
+through a notebook.
+
+---
+
+## Priority 4 — Robustness and completeness
+
+### 4.1 Add `save` / `load`
+
+`joblib` is already a dependency (used only for `Memory` so far). Add
+`PoniardBaseEstimator.save(path)` and `PoniardBaseEstimator.load(path)`
+classmethods that joblib-dump the whole estimator. The whole pitch is "fast
+first pass" — first passes get shown to teammates and re-opened later.
+Pickle round-trip should be tested as part of CI: fit → save → load →
+`get_results` → assert identical.
+
+Storing `X`/`y` on the estimator (see 3.2) makes this trivial. Decide whether
+they should be saved with the estimator or dropped on save (memory leak
+concern); a `save(path, include_data=True)` flag is one option.
+
+### 4.2 Replace frame-introspection repr
+
+`get_kwargs` (in `poniard/utils/helpers.py`) introspects `inspect.currentframe`
+to read `f_back.f_locals` and reconstruct constructor kwargs for `__repr__`.
+It's clever and brittle — breaks if `__init__` is decorated, partial-applied,
+or if anyone calls `super().__init__` from anywhere but the direct caller.
+`_init_params` is stored on both `PoniardBaseEstimator` and
+`PoniardPreprocessor` purely to support this.
+
+Replace by capturing kwargs explicitly in `__init__`:
+
+```python
+def __init__(self, **kwargs):
+    self._init_params = {**kwargs}
+    ...
+```
+
+or by enumerating the constructor params and reading them back from `self` at
+repr time. Either way, remove the frame walk.
+
+### 4.3 Stop stateful side effects in `PoniardPreprocessor._infer_dtypes`
+
+`_infer_dtypes` mutates `self.numeric_threshold` and
+`self.cardinality_threshold` from floats to ints as a side effect, so a second
+`build` with different `X` silently uses the converted ints. Keep the
+constructor values pristine; compute the int thresholds into local variables
+(or a separate `_resolved_numeric_threshold` attribute) and use those.
+
+### 4.4 Decouple `_process_results` from cross_validate column order
+
+`_process_results` reorders columns by `list(means.columns[2:]) + ["fit_time",
+"score_time"]`, relying on the convention that columns 0–1 from
+`cross_validate`'s output dict are the times. This is brittle against sklearn
+output-order changes. Instead, select by name: identify time columns by name
+(`fit_time`, `score_time`) and the rest as metrics. No positional assumptions.
+
+### 4.5 Clarify prediction semantics
+
+`_predict` initializes `result = np.empty(y.shape); result[:] = np.nan` for
+estimators without `predict_proba`/`decision_function`. For 2-D `y` this
+silently fills a same-shape NaN array, possibly masking real issues. Either
+raise a clear error ("estimator X does not support method Y") or document the
+NaN-fill as intentional and make the shape precise. Test both paths.
+
+---
+
+## Priority 5 — Cleanup
+
+- **Document the `PONIARD_TQDM_LEAVE` env var** in the README (it's currently
+  discoverable only by reading source).
+- **`get_results(wrt_dummy=True)`**: ratio of stds is not meaningful; either
+  drop stds from that view or document it as "ratio of means only." Also the
+  multiple-Dummy squeeze case should be tested.
+- **`get_predictions_similarity`** excludes dummies by substring match
+  (`"DummyClassifier"` / `"DummyRegressor"`), not by `poniard_task`. Switch to
+  checking the estimator class for `Dummy*` via isinstance, or just exclude
+  by the standard prefix.
+- **XGBoost grids** go away with 2.3 — confirm no lingering references.
+- **`_fitted_pipeline_ids`** replacement (1.3) — verify
+  `add_preprocessing_step` and `reassign_types` clear the fitted set so a
+  re-fit after reconfiguring re-runs everything.
+- **The `poniard_task` isinstance + deferred import** in `core.py` — leave as
+  is for now; it's awkward but works. Revisit only if we ever add a third task
+  type (which we won't).
+
+---
+
+## Testing summary
+
+Add tests for (in order of urgency):
+
+| Module | Current coverage | Needed |
+|---|---|---|
+| `ErrorAnalyzer` | none | full coverage — see 3.1 |
+| `PoniardPlotFactory` | none | smoke per method — see 3.4 |
+| `tune_estimator` after grid deletion (2.3) | partial | explicit-grid path, error path |
+| `save`/`load` round-trip (4.1) | none | fit → save → load → identical results |
+| `get_estimator` no-poniard pickling (2.2) | none | subprocess pickle load without poniard |
+| `wrt_dummy=True` multiple dummies (4.x) | none | numerical correctness |
+| `reassign_types` roundtrip | none | assign → fit → get_results sane |
+| `cache_transformations` cleanup | none | temp dir is removed |
+
+---
+
+## Sequencing
+
+Do them in this order — each step unblocks or de-risks the next:
+
+1. **1.1** (side effects) and **1.3** (`id()` → names) — small, mechanical,
+   high trust.
+2. **1.2** (`ErrorAnalyzer` bugs) and **3.1** (its tests) — fixes the most
+   differentiated module and locks it in.
+3. **2.3** (delete grids) and **2.5** (tighten default estimators) — sharpens
+   the opinionated surface.
+4. **2.1** (de-duplicate `setup`/`fit`) — now safe because the fitted-tracking
+   is by name.
+5. **2.2** (`get_estimator` as exporter) + its pickle-without-poniard test.
+6. **4.1** (`save`/`load`), **4.3**, **4.4** — robustness pass.
+7. **3.2**–**3.4** and **4.2** — polish the analysis layer.
+8. **2.4** and Priority 5 — surface cleanup, last, lowest risk.

--- a/poniard/__init__.py
+++ b/poniard/__init__.py
@@ -1,11 +1,7 @@
 from importlib.metadata import version
 
-from sklearn import set_config
-
 from poniard.estimators.classification import PoniardClassifier
 from poniard.estimators.regression import PoniardRegressor
-
-set_config(transform_output="pandas")
 
 __version__ = version("poniard")
 __all__ = ["PoniardClassifier", "PoniardRegressor"]

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -191,6 +191,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             else:
                 self.preprocessor = self._build_preprocessor(X, y)
             self._pass_instance_attrs(self.preprocessor)
+            self._ensure_pandas_output(self.preprocessor)
 
         if self.show_info:
             self._print_setup_info()
@@ -285,13 +286,39 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         return []
 
     def _make_pipeline(self, name: str, estimator) -> Pipeline:
-        """Create a Pipeline for an estimator, optionally including the preprocessor."""
+        """Create a Pipeline for an estimator, optionally including the preprocessor.
+
+        The wrapping pipeline is configured to output pandas DataFrames on
+        ``transform``. This propagates to any preprocessor step (including a
+        user-supplied custom one) so downstream code keeps the pandas contract
+        without relying on a global sklearn config.
+        """
         if self.preprocess:
-            return Pipeline(
+            pipe = Pipeline(
                 [("preprocessor", self.preprocessor), (name, estimator)],
                 memory=self._memory,
             )
-        return Pipeline([(name, estimator)])
+        else:
+            pipe = Pipeline([(name, estimator)])
+        if self.preprocess:
+            pipe.set_output(transform="pandas")
+        return pipe
+
+    @staticmethod
+    def _ensure_pandas_output(estimator) -> None:
+        """Configure a preprocessor (Pipeline or ColumnTransformer) to output
+        pandas DataFrames on ``transform``.
+
+        Called for user-supplied custom preprocessors that are not
+        ``PoniardPreprocessor`` instances, so the pandas in/out contract is
+        honored without relying on a global sklearn config.
+        """
+        set_output = getattr(estimator, "set_output", None)
+        if callable(set_output):
+            try:
+                estimator.set_output(transform="pandas")
+            except (TypeError, ValueError):
+                pass
 
     @staticmethod
     def _generate_estimator_name(
@@ -435,6 +462,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             else:
                 self.preprocessor = self._build_preprocessor(X, y)
             self._pass_instance_attrs(self.preprocessor)
+            self._ensure_pandas_output(self.preprocessor)
 
         if self.show_info:
             self._print_setup_info()

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -16,7 +16,6 @@ from ..utils.estimate import element_to_list_maybe
 
 try:
     import plotly.express as px
-    import plotly.io as pio
     from plotly.graph_objs._figure import Figure
     from plotly.subplots import make_subplots
 except ImportError as e:
@@ -62,18 +61,34 @@ class PoniardPlotFactory:
         self._font_family = plot_config.get("font_family", "Helvetica")
         self._font_color = plot_config.get("font_color", "#8C8C8C")
 
-        pio.templates.default = self._template
-        pio.templates["plotly_white"].layout.font = {
-            "family": self._font_family,
-            "color": self._font_color,
+    def _apply_layout(self, fig: Figure) -> Figure:
+        """Apply the configured template, font, margin, and legend to a figure.
+
+        No global plotly state is mutated.
+        """
+        fig.update_layout(
+            template=self._template,
+            font={"family": self._font_family, "color": self._font_color},
+            margin={"l": 20, "r": 20},
+            legend={
+                "yanchor": "top",
+                "y": -0.2,
+                "xanchor": "left",
+                "x": 0.0,
+                "orientation": "h",
+            },
+        )
+        return fig
+
+    def _px_kwargs(self, kwargs: dict | None = None) -> dict:
+        """Build the kwargs dict for `px.*` calls, including plot_config defaults."""
+        merged = {
+            "template": self._template,
+            "color_discrete_sequence": self._discrete_colors,
         }
-        pio.templates["plotly_white"].layout.margin = {"l": 20, "r": 20}
-        pio.templates["plotly_white"].layout.legend.yanchor = "top"
-        pio.templates["plotly_white"].layout.legend.y = -0.2
-        pio.templates["plotly_white"].layout.legend.xanchor = "left"
-        pio.templates["plotly_white"].layout.legend.x = 0.0
-        pio.templates["plotly_white"].layout.legend.orientation = "h"
-        px.defaults.color_discrete_sequence = self._discrete_colors
+        if kwargs:
+            merged.update(kwargs)
+        return merged
 
     def metrics(
         self,
@@ -140,7 +155,7 @@ class PoniardPlotFactory:
                 facet_col=facet_col,
                 title="Model scores",
                 height=height,
-                **kwargs,
+                **self._px_kwargs(kwargs),
             )
         else:
             stds = self._estimator._stds.reset_index().melt(id_vars="index")
@@ -164,10 +179,11 @@ class PoniardPlotFactory:
                 orientation="h",
                 title="Model scores",
                 height=height,
-                **kwargs,
+                **self._px_kwargs(kwargs),
             )
         fig.update_xaxes(matches=None)
         fig.update_layout(yaxis_title="")
+        self._apply_layout(fig)
 
         return fig
 
@@ -210,8 +226,10 @@ class PoniardPlotFactory:
             y="Model",
             x=results.columns[0],
             title=f"{metric} overfitness",
+            **self._px_kwargs(),
         )
         fig.update_layout(xaxis_title="Train / test ratio", yaxis_title="")
+        self._apply_layout(fig)
         return fig
 
     def permutation_importance(
@@ -290,13 +308,21 @@ class PoniardPlotFactory:
                 y="Feature",
                 color="Type",
                 title=title,
+                **self._px_kwargs(),
             )
         else:
             importances = importances.loc[
                 -importances["Type"].isin(["Repetition", "Std"])
             ]
-            fig = px.bar(importances, x="Importance", y="Feature", title=title)
+            fig = px.bar(
+                importances,
+                x="Importance",
+                y="Feature",
+                title=title,
+                **self._px_kwargs(),
+            )
             fig.update_layout(yaxis={"categoryorder": "total ascending"})
+        self._apply_layout(fig)
         return fig
 
     def roc_curve(
@@ -392,6 +418,7 @@ class PoniardPlotFactory:
                 "False positive rate": ":.2f",
                 "AUC": ":.2f",
             },
+            **self._px_kwargs(),
         )
         fig.update_layout(
             shapes=[
@@ -407,6 +434,7 @@ class PoniardPlotFactory:
                 }
             ]
         )
+        self._apply_layout(fig)
         return fig
 
     def confusion_matrix(self, estimator_name: str, **kwargs) -> Figure:
@@ -437,10 +465,12 @@ class PoniardPlotFactory:
             color_continuous_scale="Blues",
             text_auto=True,
             title="Confusion matrix with cross-validated predictions",
+            **self._px_kwargs(),
         )
         fig.update_yaxes(nticks=len(np.unique(y)) + 1)
         fig.update_xaxes(nticks=len(np.unique(y)) + 1)
         fig.update(layout_coloraxis_showscale=False)
+        self._apply_layout(fig)
         return fig
 
     def partial_dependence(
@@ -493,9 +523,11 @@ class PoniardPlotFactory:
             y="Target",
             color="Class",
             title=f"Average partial dependence between feature '{feature}' and target",
+            **self._px_kwargs(),
         )
         if hide_legend:
             fig.update_layout(showlegend=False)
+        self._apply_layout(fig)
         return fig
 
     def _build_residuals_data(self, estimator_names: list[str]) -> pd.DataFrame:
@@ -544,7 +576,9 @@ class PoniardPlotFactory:
             color="Estimator",
             symbol="Target" if "Target" in data.columns else None,
             title="Residuals plot with cross validated predictions",
+            **self._px_kwargs(),
         )
+        self._apply_layout(fig)
         return fig
 
     def residuals_histogram(self, estimator_names: list[str]) -> Figure:
@@ -573,7 +607,9 @@ class PoniardPlotFactory:
             histnorm="percent",
             barmode="overlay",
             title="Residuals histogram plot with cross validated predictions",
+            **self._px_kwargs(),
         )
+        self._apply_layout(fig)
         return fig
 
     def _full_estimator_analysis(
@@ -611,7 +647,11 @@ class PoniardPlotFactory:
             ascending=False
         )
         rankings = pd.concat([metric_rankings, time_rankings], axis=1)
-        rank = px.bar(rankings.loc[estimator_name, :], text_auto=True)
+        rank = px.bar(
+            rankings.loc[estimator_name, :],
+            text_auto=True,
+            **self._px_kwargs(),
+        )
         rank_title = f"Metrics rank (best={len(self._estimator.pipelines)})"
         rank.update_layout(dict(xaxis_title=None, yaxis_title="Rank"), showlegend=False)
 
@@ -677,4 +717,5 @@ class PoniardPlotFactory:
                 "showscale": False,
             }
         )
+        self._apply_layout(plot_array)
         return plot_array

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import tempfile
 import warnings
 from typing import TYPE_CHECKING
 
@@ -58,6 +60,10 @@ class PoniardPreprocessor:
     cache_transformations :
         Whether to cache transformations and set the `memory` parameter for Pipelines. This can
         speed up slow transformations as they are not recalculated for each estimator.
+    cache_dir :
+        Directory used to cache transformations when ``cache_transformations`` is True. If None
+        (the default), a temporary directory is created and cleaned up when the preprocessor is
+        garbage collected. If a path is provided, the user is responsible for its contents.
     verbose :
         Verbosity level. Propagated to every scikit-learn function and estimator.
     random_state :
@@ -81,6 +87,7 @@ class PoniardPreprocessor:
         random_state: int | None = None,
         n_jobs: int | None = None,
         cache_transformations: bool = False,
+        cache_dir: str | os.PathLike | None = None,
     ):
         self._init_params = get_kwargs()
         self.task = task
@@ -92,8 +99,14 @@ class PoniardPreprocessor:
         self.verbose = verbose
         self.random_state = random_state or 0
         self.n_jobs = n_jobs
+        self._cache_tempdir = None
         if cache_transformations:
-            self._memory = joblib.Memory("transformation_cache", verbose=self.verbose)
+            if cache_dir is None:
+                self._cache_tempdir = tempfile.TemporaryDirectory(
+                    prefix="poniard_cache_"
+                )
+                cache_dir = self._cache_tempdir.name
+            self._memory = joblib.Memory(str(cache_dir), verbose=self.verbose)
         else:
             self._memory = None
 
@@ -207,6 +220,7 @@ class PoniardPreprocessor:
         type_preprocessor.transformers = non_empty_transformers
         if len(type_preprocessor.transformers) == 1:
             type_preprocessor = type_preprocessor.transformers[0][1]
+        type_preprocessor.set_output(transform="pandas")
         preprocessor = Pipeline(
             [
                 ("type_preprocessor", type_preprocessor),
@@ -214,6 +228,7 @@ class PoniardPreprocessor:
             ],
             memory=self._memory,
         )
+        preprocessor.set_output(transform="pandas")
         self.preprocessor = preprocessor
         return self
 

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -1,0 +1,194 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+
+from poniard import PoniardClassifier
+from poniard.preprocessing import PoniardPreprocessor
+
+
+def test_importing_poniard_does_not_change_sklearn_global_config():
+    """Importing poniard must not mutate sklearn's global ``transform_output`` config."""
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sklearn; sklearn.set_config(transform_output='default'); "
+            "import poniard; "
+            "from sklearn import get_config; "
+            "assert get_config()['transform_output'] == 'default', get_config()",
+        ],
+        check=True,
+    )
+
+
+def test_preprocessor_outputs_pandas_without_global_set_config():
+    """The preprocessor's Pipeline must return pandas DataFrames on its own,
+    without depending on a global sklearn set_config call."""
+    from sklearn import set_config
+
+    set_config(transform_output="default")
+    try:
+        preprocessor = PoniardPreprocessor(task="classification")
+        X = pd.DataFrame(
+            {
+                "A": [4.0, 3.0, 1.0, -1.0, np.nan],
+                "B": [-2.0, np.nan, 3.0, 7.0, 1.0],
+                "C": list("abcde"),
+            }
+        )
+        y = pd.Series([0, 1, 0, 1, 0])
+        preprocessor.build(X=X, y=y, task="classification")
+        preprocessor.preprocessor.fit(X, y)
+        transformed = preprocessor.preprocessor.transform(X)
+        assert isinstance(transformed, pd.DataFrame)
+    finally:
+        set_config(transform_output="default")
+
+
+def test_cache_transformations_does_not_write_to_cwd(tmp_path, monkeypatch):
+    """``cache_transformations=True`` must not create a directory in the current
+    working directory; the cache should live under a temp dir by default."""
+    monkeypatch.chdir(tmp_path)
+    preprocessor = PoniardPreprocessor(
+        task="classification",
+        cache_transformations=True,
+    )
+    preprocessor.build(
+        X=pd.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0]}), y=pd.Series([0, 1, 0, 1, 0])
+    )
+    cwd_contents = list(tmp_path.iterdir())
+    assert cwd_contents == [], f"Files were created in CWD: {cwd_contents}"
+    assert preprocessor._memory is not None
+    assert preprocessor._cache_tempdir is not None
+    cache_path = Path(preprocessor._cache_tempdir.name)
+    assert cache_path.exists()
+    # cleanup happens automatically on garbage collection; force it here
+    del preprocessor
+    import gc
+
+    gc.collect()
+    assert not cache_path.exists()
+
+
+def test_cache_transformations_with_explicit_cache_dir(tmp_path):
+    """A user-provided ``cache_dir`` is honored and the user owns its contents."""
+    user_dir = tmp_path / "my_cache"
+    preprocessor = PoniardPreprocessor(
+        task="classification",
+        cache_transformations=True,
+        cache_dir=user_dir,
+    )
+    preprocessor.build(
+        X=pd.DataFrame({"A": [1.0, 2.0, 3.0, 4.0, 5.0]}), y=pd.Series([0, 1, 0, 1, 0])
+    )
+    assert preprocessor._cache_tempdir is None
+    assert preprocessor._memory is not None
+    assert preprocessor._memory.location == str(user_dir)
+    assert user_dir.exists()
+
+
+def test_cache_transformations_false_means_no_memory():
+    preprocessor = PoniardPreprocessor(
+        task="classification",
+        cache_transformations=False,
+    )
+    assert preprocessor._memory is None
+    assert preprocessor._cache_tempdir is None
+
+
+def test_plot_factory_does_not_mutate_plotly_globals():
+    """Constructing PoniardPlotFactory and rendering a figure must not mutate
+    plotly's global template or default color sequence."""
+    code = (
+        "import plotly.express as px, plotly.io as pio; "
+        "from poniard import PoniardClassifier; "
+        "before_t = pio.templates.default; "
+        "before_c = px.defaults.color_discrete_sequence; "
+        "from poniard.plot import PoniardPlotFactory; "
+        "import numpy as np, pandas as pd; "
+        "from sklearn.linear_model import LogisticRegression; "
+        "X = pd.DataFrame(np.random.normal(size=(30, 3)), columns=list('abc')); "
+        "X['s'] = np.random.choice(['x','y','z'], size=30); "
+        "y = np.random.choice([0,1], size=30); "
+        "clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0); "
+        "clf.setup(X, y); clf.fit(X, y); "
+        "plotter = PoniardPlotFactory(X, y, clf); "
+        "plotter.metrics(); "
+        "assert pio.templates.default == before_t, (pio.templates.default, before_t); "
+        "assert px.defaults.color_discrete_sequence == before_c, "
+        "(px.defaults.color_discrete_sequence, before_c); "
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_plot_factory_applies_per_figure_template_and_colors():
+    """The template and discrete colors passed at construction must end up on
+    the returned figure, not on the plotly globals."""
+    import plotly.graph_objects as go
+
+    from poniard.plot import PoniardPlotFactory
+
+    X = pd.DataFrame(np.random.normal(size=(30, 3)), columns=list("abc"))
+    X["s"] = np.random.choice(["x", "y", "z"], size=30)
+    y = np.random.choice([0, 1], size=30)
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
+    clf.setup(X, y)
+    clf.fit(X, y)
+
+    plotter = PoniardPlotFactory(
+        X,
+        y,
+        clf,
+        discrete_colors=["#112233", "#445566", "#778899"],
+        font_family="Courier",
+        font_color="#abcdef",
+    )
+    fig = plotter.metrics()
+    assert isinstance(fig, go.Figure)
+    assert fig.layout.font.family == "Courier"
+    assert fig.layout.font.color == "#abcdef"
+    # Legend orientation matches the original config
+    assert fig.layout.legend.orientation == "h"
+
+
+def test_custom_sklearn_preprocessor_outputs_pandas_without_global_set_config():
+    """A user-supplied custom preprocessor (plain sklearn Pipeline) must also
+    output pandas DataFrames when transformed, without depending on a global
+    sklearn set_config call."""
+    from sklearn import set_config
+    from sklearn.base import clone
+    from sklearn.impute import SimpleImputer
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    set_config(transform_output="default")
+    try:
+        n = 50
+        X = pd.DataFrame({"num": np.random.normal(size=n)})
+        X.iloc[0, 0] = np.nan
+        y = np.zeros(n, dtype=int)
+        y[::2] = 1
+        custom = Pipeline(
+            [("imputer", SimpleImputer()), ("scaler", StandardScaler())]
+        )
+        clf = PoniardClassifier(
+            estimators=[LogisticRegression()],
+            custom_preprocessor=custom,
+            preprocess=True,
+            cv=2,
+            random_state=0,
+        )
+        clf.setup(X, y)
+        # Poniard must configure the user-supplied preprocessor to output
+        # pandas so a fitted clone produces a DataFrame even when the global
+        # sklearn config is "default".
+        fitted = clone(clf.preprocessor)
+        fitted.fit(X, y)
+        out = fitted.transform(X)
+        assert isinstance(out, pd.DataFrame)
+    finally:
+        set_config(transform_output="default")


### PR DESCRIPTION
## Summary

Addresses ROADMAP item 1.1: remove global side effects on import.

Importing poniard no longer mutates sklearn or plotly global state. The pandas in/out contract is preserved by setting `transform_output` on the preprocessor's own instances and on the wrapping pipeline, instead of calling `sklearn.set_config` globally.

## Changes

**`poniard/__init__.py`**
- Drop `sklearn.set_config(transform_output="pandas")` and the `set_config` import.

**`PoniardPreprocessor` (`poniard/preprocessing/core.py`)**
- Call `set_output(transform="pandas")` on the inner `ColumnTransformer` / single-transformer branch and on the outer `Pipeline`, so the pandas output is local to Poniard objects.
- New `cache_dir: str | os.PathLike | None = None` argument. When `cache_transformations=True` and no `cache_dir` is provided, a `tempfile.TemporaryDirectory(prefix="poniard_cache_")` is created and cleaned up on GC. The hardcoded `transformation_cache/` in CWD is gone.

**`PoniardBaseEstimator` (`poniard/estimators/core.py`)**
- New `_ensure_pandas_output()` helper that calls `set_output(transform="pandas")` on a preprocessor if it supports it. Called from `setup()` and `fit()` so user-supplied custom preprocessors (plain sklearn `Pipeline` / `ColumnTransformer` / transformer) also output pandas without relying on global config.
- `_make_pipeline()` now sets `set_output(transform="pandas")` on the wrapping pipeline so the cross-validated clone of any user-supplied inner preprocessor inherits the pandas setting on fit.

**`PoniardPlotFactory` (`poniard/plot/plot_factory.py`)**
- Drop all `pio.templates` and `px.defaults` mutations from `__init__`.
- New `_apply_layout(fig)` helper applies the configured template, font, margin, and legend per figure.
- New `_px_kwargs(kwargs)` helper injects `template` and `color_discrete_sequence` into every `px.*` call. User kwargs still take precedence.
- All public methods (`metrics`, `overfitness`, `permutation_importance`, `roc_curve`, `confusion_matrix`, `partial_dependence`, `residuals`, `residuals_histogram`, `_full_estimator_analysis`) end with `_apply_layout(fig)`.

## Tests

New `tests/test_side_effects.py` (8 tests):
- Importing poniard does not change sklearn's global `transform_output` (subprocess assertion).
- `PoniardPreprocessor` outputs pandas without global `set_config` being set to "pandas".
- User-supplied custom preprocessor (plain sklearn `Pipeline`) outputs pandas without global config.
- `cache_transformations=True` writes nothing to CWD; the temp dir is removed on GC.
- User-provided `cache_dir` is honored and the user owns it.
- `cache_transformations=False` leaves `_memory` as `None`.
- `PoniardPlotFactory` does not mutate `pio.templates.default` or `px.defaults.color_discrete_sequence` (subprocess assertion).
- Per-figure `template`, `font_family`, `font_color`, and legend orientation are honored.

## Verification

- `uv run pytest`: 95/95 passing (87 prior + 8 new).
- `uv run ruff check poniard/ tests/`: clean.