### PR TITLE
feat: overhaul error analysis (roadmap 1.2, 3.1-3.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,45 @@ plotter.confusion_matrix("LogisticRegression")
 plotter.permutation_importance("LogisticRegression")
 ```
 
+## Error analysis
+
+`ErrorAnalyzer` answers *where and why* your models fail. Build it from a
+fitted `PoniardClassifier` / `PoniardRegressor` and run the full workflow with
+a single call:
+
+```python
+from poniard.error_analysis import ErrorAnalyzer
+
+ea = ErrorAnalyzer.from_poniard(clf, estimator_names=["LogisticRegression", "RandomForestClassifier"])
+report = ea.analyze(X, y)  # X, y = the data you fitted on
+```
+
+`report` contains:
+
+- `ranked_errors` — per estimator, samples sorted by error magnitude
+- `merged_errors` — per sample, how many estimators failed and their average error
+- `summary` — per estimator: number of errors and error rate
+- `by_target` — error counts and error rate per target class/bin
+- `by_feature` — per feature, the distribution of errors across its values
+
+The individual steps are also exposed:
+
+```python
+ranked = ea.rank_errors(X, y)                       # per-estimator ranked errors
+merged = ErrorAnalyzer.merge_errors(ranked)         # cross-estimator view
+ea.analyze_target(errors_idx=merged.index, y=y)     # errors vs target distribution
+ea.analyze_features(errors_idx=merged.index, X=X)   # errors vs feature values
+```
+
+How errors are defined:
+
+- **Classification**: misclassified samples, ranked by `1 - probability of the
+  truth` (how confidently wrong the model is). Multilabel targets rank by the
+  mean per-label deviation.
+- **Regression**: samples whose absolute residual exceeds a threshold, ranked by
+  residual magnitude. The threshold defaults to the 90th percentile of residuals
+  and can be configured with `error_quantile` in `rank_errors` / `analyze`.
+
 ## Estimator naming
 
 Each estimator gets a name automatically (its class name). You can override with tuple syntax:
@@ -88,6 +127,7 @@ clf = PoniardClassifier(estimators=[('my_lr', LogisticRegression())])
 - **Cross-validated comparison**: Fits multiple estimators with cross-validation and collects results
 - **Hyperparameter tuning**: Grid, random, and halving search for any estimator
 - **Ensemble building**: Create ensembles from fitted estimators
+- **Error analysis**: Rank prediction errors, and analyze them against the target and features to find *where and why* models fail
 - **Plotting**: Metrics comparison, ROC curves, confusion matrices, feature importance (optional, requires plotly)
 
 ## Python support

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.inspection import permutation_importance
+from sklearn.model_selection import train_test_split
 
 if TYPE_CHECKING:
     from poniard.estimators.core import PoniardBaseEstimator
@@ -18,12 +19,23 @@ from ..utils.utils import get_kwargs, non_default_repr
 
 
 class ErrorAnalyzer:
-    """An error analyzer for predictive models.
+    """Analyze where and why predictive models fail.
 
-    Compare ground truth and predicted target and rank the largest deviations
-    (either by probabilities for classifiers and actual values for regressors).
+    Compare ground truth and predicted target, rank the largest deviations and
+    cross-tabulate them against the target and the features. "Error" is defined
+    as:
 
-    This class is tightly integrated with `PoniardBaseEstimator`, but does not require it.
+    * binary / multiclass: samples the model got wrong, ranked by
+      ``1 - probability_of_truth`` (i.e. how confidently wrong the model is).
+    * multilabel: samples the model got wrong on at least one label, ranked by
+      the mean per-label deviation.
+    * regression / multioutput regression: samples whose absolute residual is
+      above a threshold, ranked by residual magnitude. The threshold defaults to
+      the 90th percentile of absolute residuals and can be configured via
+      ``error_quantile``.
+
+    This class is tightly integrated with `PoniardBaseEstimator` (via
+    `from_poniard`) but does not require it.
 
     Parameters
     ----------
@@ -46,7 +58,7 @@ class ErrorAnalyzer:
     ) -> ErrorAnalyzer:
         """Use a Poniard instance to instantiate `ErrorAnalyzer`.
 
-        Automatically sets the task and gives access to the underlying data.
+        Automatically sets the task, the estimator names and the target type.
 
         Parameters
         ----------
@@ -66,36 +78,42 @@ class ErrorAnalyzer:
         error_analysis.type_of_target = poniard.target_info["type_"]
         return error_analysis
 
-    def _compute_predictions(self):
-        """Compute predictions for Poniard estimators."""
-        predictions = self._poniard.predict(estimator_names=self.estimator_names)
+    def _compute_predictions(self, X, y):
+        """Compute cross-validated predictions for the selected estimators."""
+        predictions = self._poniard.predict(
+            X=X, y=y, estimator_names=self.estimator_names
+        )
         probas = None
         if self.type_of_target in ["binary", "multilabel-indicator", "multiclass"]:
-            probas = self._poniard.predict_proba(estimator_names=self.estimator_names)
+            probas = self._poniard.predict_proba(
+                X=X, y=y, estimator_names=self.estimator_names
+            )
         return predictions, probas
 
     def rank_errors(
         self,
+        X: np.ndarray | pd.DataFrame | None = None,
         y: np.ndarray | pd.Series | pd.DataFrame | None = None,
         predictions: np.ndarray | pd.Series | pd.DataFrame | None = None,
         probas: np.ndarray | pd.Series | pd.DataFrame | None = None,
         exclude_correct: bool = True,
+        error_quantile: float = 0.1,
     ):
-        """Compare the `y` ground truth with `predictions` and `probas` and sort by the largest deviations.
+        """Rank samples by error for each estimator.
 
-        If `ErrorAnalyzer.from_poniard` was used, no data needs to be passed to this method.
+        When using `ErrorAnalyzer.from_poniard`, `X` and `y` must be passed so
+        that cross-validated predictions can be computed. Otherwise, pass
+        `predictions` (and `probas` for classification) directly.
 
-        In this context "error" refers to:
-
-        * misclassified samples in binary and multiclass problems.
-        * misclassified samples in any of the labels for multilabel problems.
-        * samples with predicted values outside the `truth - 1SD <-> truth + 1SD`
-        range for regression problems.
-        * samples with predicted values outside the `truth - 1SD <-> truth + 1SD`
-        range in any of the targets for multioutput regression problems.
+        For regression, ``exclude_correct`` keeps only the samples whose
+        absolute residual exceeds a threshold, defaulting to the
+        ``error_quantile`` (default 0.1) worst residuals. For classification it
+        keeps only misclassified samples.
 
         Parameters
         ----------
+        X :
+            Features. Required when using `ErrorAnalyzer.from_poniard`.
         y :
             Ground truth target.
         predictions :
@@ -103,30 +121,48 @@ class ErrorAnalyzer:
         probas :
             Predicted probabilities for each class in classification tasks.
         exclude_correct :
-            Whether to exclude correctly predicted samples in the output ranking. Default True.
+            Whether to exclude correctly predicted samples from the ranking.
+            Default True.
+        error_quantile :
+            Fraction of worst residuals kept as errors for regression tasks
+            when ``exclude_correct`` is True. Default 0.1.
 
         Returns
         -------
-        dict
-            Ranked errors
+        dict[str, pd.DataFrame] | pd.DataFrame
+            A DataFrame per estimator (keys are estimator names) when built via
+            `from_poniard`, or a single DataFrame otherwise. Each DataFrame is
+            indexed by sample and includes a `error` column used for ranking.
         """
         if self._has_poniard:
-            y = self._poniard.y
-            predictions, probas = self._compute_predictions()
-            type_of_target = self.type_of_target
+            if X is None or y is None:
+                raise ValueError(
+                    "X and y must be provided when using `from_poniard`."
+                )
+            predictions, probas = self._compute_predictions(X, y)
             ranked_errors = {}
             for estimator in self.estimator_names:
                 proc_probas = probas[estimator] if probas is not None else probas
-                estimator_errors = self._target_redirect(type_of_target)(
-                    y, predictions[estimator], proc_probas, exclude_correct
+                ranked_errors[estimator] = self._rank_single(
+                    y,
+                    predictions[estimator],
+                    proc_probas,
+                    exclude_correct,
+                    error_quantile,
                 )
-                ranked_errors.update({estimator: estimator_errors})
             return ranked_errors
-        else:
-            self.type_of_target = get_target_info(y, task=self.task)["type_"]
-            return self._target_redirect(self.type_of_target)(
-                y, predictions, probas, exclude_correct
-            )
+        self.type_of_target = get_target_info(y, task=self.task)["type_"]
+        return self._rank_single(
+            y, predictions, probas, exclude_correct, error_quantile
+        )
+
+    def _rank_single(
+        self, y, predictions, probas, exclude_correct, error_quantile
+    ) -> pd.DataFrame:
+        """Rank errors for a single set of predictions."""
+        return self._target_redirect(self.type_of_target)(
+            y, predictions, probas, exclude_correct, error_quantile
+        )
 
     def _target_redirect(self, type_of_target: str):
         """A router for error ranking depending on the type of the target."""
@@ -145,11 +181,12 @@ class ErrorAnalyzer:
 
     def _rank_errors_binary(
         self,
-        y: np.ndarray | pd.Series | pd.DataFrame,
-        predictions: np.ndarray | pd.Series | pd.DataFrame,
-        probas: np.ndarray | pd.Series | pd.DataFrame,
+        y,
+        predictions,
+        probas,
         exclude_correct: bool = True,
-    ):
+        error_quantile: float = 0.1,
+    ) -> pd.DataFrame:
         errors = pd.DataFrame(
             {
                 "y": y,
@@ -161,171 +198,177 @@ class ErrorAnalyzer:
         if exclude_correct:
             errors = errors.query("y != prediction")
         errors = errors.assign(error=(errors["y"] - errors["proba_1"]).abs())
-        ranked_errors = errors.sort_values("error", ascending=False)
-        return {"values": ranked_errors, "idx": ranked_errors.index}
+        return errors.sort_values("error", ascending=False)
 
     def _rank_errors_multiclass(
         self,
-        y: np.ndarray | pd.Series | pd.DataFrame,
-        predictions: np.ndarray | pd.Series | pd.DataFrame,
-        probas: np.ndarray | pd.Series | pd.DataFrame,
+        y,
+        predictions,
+        probas,
         exclude_correct: bool = True,
-    ):
+        error_quantile: float = 0.1,
+    ) -> pd.DataFrame:
         data = {"y": y, "prediction": predictions}
         data.update({f"proba_{i}": probas[:, i] for i in range(len(np.unique(y)))})
         errors = pd.DataFrame(data)
         if exclude_correct:
             errors = errors.query("y != prediction")
         errors = errors.assign(
-            truth_proba=[
-                errors[f"proba_{truth}"].iloc[idx]
-                for idx, truth in enumerate(errors["y"])
-            ]
+            truth_proba=errors.apply(
+                lambda row: row[f"proba_{int(row['y'])}"], axis=1
+            )
         )
         errors = errors.assign(error=(1 - errors["truth_proba"]).abs())
-        ranked_errors = errors.sort_values("error", ascending=False)
-        return {"values": ranked_errors, "idx": ranked_errors.index}
+        return errors.sort_values("error", ascending=False)
 
     def _rank_errors_multilabel(
         self,
-        y: np.ndarray | pd.Series | pd.DataFrame,
-        predictions: np.ndarray | pd.Series | pd.DataFrame,
-        probas: np.ndarray | pd.Series | pd.DataFrame,
+        y,
+        predictions,
+        probas,
         exclude_correct: bool = True,
-    ):
+        error_quantile: float = 0.1,
+    ) -> pd.DataFrame:
         n_labels = y.shape[1]
         truth = pd.DataFrame(y, columns=[f"y_{i}" for i in range(n_labels)])
         preds = pd.DataFrame(predictions, columns=[f"prediction_{i}" for i in range(n_labels)])
         pro = pd.DataFrame(probas, columns=[f"proba_{i}" for i in range(n_labels)])
         errors = pd.concat([truth, preds, pro], axis=1)
         if exclude_correct:
-            errors = errors.loc[~preds.eq(y).all(axis=1)]
-        errors_per_label = (
-            errors[truth.columns].sub(errors[pro.columns].values, axis=1)
-        ).abs()
-        errors_per_label.columns = [f"error_{i}" for i in range(n_labels)]
-        errors_per_label = errors_per_label.assign(error=errors_per_label.mean(axis=1))
-        errors = pd.concat([errors, errors_per_label], axis=1)
-        ranked_errors = errors.sort_values("error", ascending=False)
-        return {"values": ranked_errors, "idx": ranked_errors.index}
+            keep = ~preds.eq(y).all(axis=1)
+            errors = errors.loc[keep]
+            truth = truth.loc[keep]
+            pro = pro.loc[keep]
+        per_label = np.abs(truth.values - pro.values)
+        errors = errors.assign(
+            **{f"error_{i}": per_label[:, i] for i in range(n_labels)}
+        )
+        errors = errors.assign(
+            error=errors[[f"error_{i}" for i in range(n_labels)]].mean(axis=1)
+        )
+        return errors.sort_values("error", ascending=False)
 
     def _rank_errors_continuous(
         self,
-        y: np.ndarray | pd.Series | pd.DataFrame,
-        predictions: np.ndarray | pd.Series | pd.DataFrame,
+        y,
+        predictions,
         probas=None,
         exclude_correct: bool = True,
-    ):
+        error_quantile: float = 0.1,
+    ) -> pd.DataFrame:
         errors = pd.DataFrame({"y": y, "prediction": predictions})
-        if exclude_correct:
-            y_std = np.std(y)  # noqa: F841 - used in @y_std query below
-            errors = errors.query("prediction < y - @y_std | prediction > y + @y_std")
         errors = errors.assign(error=(errors["y"] - errors["prediction"]).abs())
-        ranked_errors = errors.sort_values("error", ascending=False)
-        return {"values": ranked_errors, "idx": ranked_errors.index}
+        if exclude_correct:
+            threshold = np.quantile(errors["error"], 1 - error_quantile)
+            errors = errors.loc[errors["error"] > threshold]
+        return errors.sort_values("error", ascending=False)
 
     def _rank_errors_continuous_multioutput(
         self,
-        y: np.ndarray | pd.Series | pd.DataFrame,
-        predictions: np.ndarray | pd.Series | pd.DataFrame,
+        y,
+        predictions,
         probas=None,
         exclude_correct: bool = True,
-    ):
+        error_quantile: float = 0.1,
+    ) -> pd.DataFrame:
         n_targets = y.shape[1]
         truth = pd.DataFrame(y, columns=[f"y_{i}" for i in range(n_targets)])
         preds = pd.DataFrame(predictions, columns=[f"prediction_{i}" for i in range(n_targets)])
         errors = pd.concat([truth, preds], axis=1)
-        if exclude_correct:
-            y_std = np.std(y, axis=0)
-            errors = errors.loc[
-                (
-                    (preds.values < truth.values - y_std)
-                    | (preds.values > truth.values + y_std)
-                ).any(axis=1)
-            ].loc[lambda x: ~x.index.duplicated()]
-        errors_per_target = pd.DataFrame(
-            np.abs(errors[truth.columns].values - errors[preds.columns].values)
-        ).set_index(errors.index)
-        errors_per_target.columns = [f"error_{i}" for i in range(n_targets)]
-        errors_per_target = errors_per_target.assign(
-            error=errors_per_target.mean(axis=1)
+        per_target = pd.DataFrame(
+            np.abs(truth.values - preds.values),
+            index=errors.index,
+            columns=[f"error_{i}" for i in range(n_targets)],
         )
-        errors = pd.concat([errors, errors_per_target], axis=1)
-        ranked_errors = errors.sort_values("error", ascending=False)
-        return {"values": ranked_errors, "idx": ranked_errors.index}
+        if exclude_correct:
+            thresholds = {
+                i: np.quantile(per_target[f"error_{i}"], 1 - error_quantile)
+                for i in range(n_targets)
+            }
+            flagged = pd.DataFrame(
+                {
+                    i: per_target[f"error_{i}"] > thresholds[i]
+                    for i in range(n_targets)
+                }
+            )
+            keep = flagged.any(axis=1)
+            errors = errors.loc[keep]
+            per_target = per_target.loc[keep]
+        errors = pd.concat(
+            [errors, per_target.assign(error=per_target.mean(axis=1))], axis=1
+        )
+        return errors.sort_values("error", ascending=False)
 
     @staticmethod
-    def merge_errors(errors: dict[str, dict[str, pd.DataFrame | pd.Series]]):
-        """Merge multiple error rankings. This is particularly useful when evaluating multiple estimators.
+    def merge_errors(errors):
+        """Merge per-estimator error rankings into a single cross-estimator view.
 
-        Compute how many estimators had the specific error and the average error between them.
-
-        This method works best when using `ErrorAnalyzer.from_poniard`, since `errors` can be
-        the output of `ErrorAnalyzer.rank_errors`. However, this is not required; as long as
-        `errors` is properly defined (`{str: {str: pd.DataFrame, str: pd.Series}}`)
+        Accepts the output of `rank_errors` (a dict of DataFrames) or a single
+        DataFrame for a lone model. The result is indexed by sample and reports,
+        per sample, how many estimators failed on it, their average error and
+        which estimators failed.
 
         Parameters
         ----------
         errors :
-            Dictionary of errors and error indexes.
-
-        Returns
-        -------
-        dict
-            Merged errors
-        """
-        concatenated = pd.concat(
-            [
-                error_dict["values"].assign(estimator=estimator)
-                for estimator, error_dict in errors.items()
-            ]
-        ).reset_index()
-        concatenated = (
-            concatenated.groupby("index")
-            .agg(
-                mean_error=pd.NamedAgg(column="error", aggfunc=np.mean),
-                freq=pd.NamedAgg(column="error", aggfunc=np.size),
-                estimators=pd.NamedAgg(
-                    column="estimator", aggfunc=lambda x: list(x)
-                ),
-            )
-            .sort_values(["freq", "mean_error"], ascending=False)
-        )
-        return {"values": concatenated, "idx": concatenated.index}
-
-    def analyze_target(
-        self,
-        errors_idx: pd.Series,
-        y: np.ndarray | pd.Series | pd.DataFrame | None = None,
-        reg_bins: int = 5,
-        as_ratio: bool = False,
-        wrt_target: bool = False,
-    ):
-        """Analyze which target classes/ranges have the most errors and compare with observed
-        target distribution.
-
-        Parameters
-        ----------
-        errors_idx :
-            Index of ranked errors.
-        y :
-            Ground truth. Not needed if using `ErrorAnalyzer.from_poniard`.
-        reg_bins :
-            Number of bins in which to place ground truth targets for regression tasks.
-        as_ratio :
-            Whether to show error ratios instead of error counts per class/bin. Default False.
-        wrt_target :
-            Whether to compute counts of errors or error ratios with respect
-            to the ground truth. Default False.
+            Output of `rank_errors`, or a single ranked-errors DataFrame.
 
         Returns
         -------
         pd.DataFrame
-            Counts per error.
+            Merged errors indexed by sample.
+        """
+        if isinstance(errors, pd.DataFrame):
+            errors = {"model": errors}
+        concatenated = pd.concat(
+            [
+                frame.assign(estimator=estimator)
+                for estimator, frame in errors.items()
+            ]
+        ).reset_index()
+        merged = (
+            concatenated.groupby("index")
+            .agg(
+                mean_error=pd.NamedAgg(column="error", aggfunc="mean"),
+                freq=pd.NamedAgg(column="error", aggfunc="size"),
+                estimators=pd.NamedAgg(column="estimator", aggfunc=lambda x: list(x)),
+            )
+            .sort_values(["freq", "mean_error"], ascending=False)
+        )
+        return merged
+
+    def analyze_target(
+        self,
+        errors_idx,
+        y: np.ndarray | pd.Series | pd.DataFrame | None = None,
+        reg_bins: int = 5,
+    ) -> pd.DataFrame:
+        """Cross-tabulate errors against the target.
+
+        For classification the target is grouped by class; for regression it is
+        binned into ``reg_bins`` quantile bins. The result reports how many
+        error samples and how many population samples each class/bin contains,
+        plus the error rate per class/bin (the interpretation column: where is
+        the model over- or under-represented in errors).
+
+        Parameters
+        ----------
+        errors_idx :
+            Index of ranked errors (e.g. the index of `merge_errors` output).
+        y :
+            Ground truth.
+        reg_bins :
+            Number of bins in which to place ground truth targets for regression
+            tasks. Default 5.
+
+        Returns
+        -------
+        pd.DataFrame
+            Counts and error rate per target class/bin.
         """
         type_of_target = self.type_of_target
-        if self._has_poniard:
-            y = self._poniard.y
+        if y is None:
+            raise ValueError("`y` must be provided.")
         y = pd.DataFrame(y)
         y_errors = y.loc[errors_idx]
 
@@ -346,110 +389,237 @@ class ErrorAnalyzer:
             target_names = list(bins.keys())
         else:
             raise NotImplementedError("Type of target could not be determined.")
-        errors_dist = y_errors.groupby(target_names).size()
-        target_dist = y.groupby(target_names).size()
-        if as_ratio:
-            errors_dist = errors_dist / errors_dist.sum()
-            target_dist = target_dist / target_dist.sum()
-        if wrt_target:
-            output = (errors_dist / target_dist).fillna(0).sort_values(ascending=False)
-        else:
-            output = pd.DataFrame(errors_dist).join(
-                pd.DataFrame(target_dist),
-                how="right",
-                lsuffix="_errors",
-                rsuffix="_target",
-            )
-            output = output.fillna(0).sort_values(by=output.columns[0], ascending=False)
+        errors_dist = y_errors.groupby(target_names, observed=True).size()
+        target_dist = y.groupby(target_names, observed=True).size()
+        output = pd.DataFrame(
+            {"error_count": errors_dist, "target_count": target_dist}
+        ).fillna(0)
+        output["error_rate"] = output["error_count"] / output[
+            "target_count"
+        ].replace(0, np.nan)
+        output = output.sort_values("error_count", ascending=False)
         return output
 
     def analyze_features(
         self,
-        errors_idx: pd.Series,
+        errors_idx,
         X: np.ndarray | pd.Series | pd.DataFrame | None = None,
+        y: np.ndarray | pd.Series | pd.DataFrame | None = None,
         features: Sequence[str | int] | None = None,
         estimator_name: str | BaseEstimator | None = None,
         n_features: int | float | None = None,
-    ):
-        """Cross tabulate features with prediction errors.
+    ) -> dict[str, pd.DataFrame]:
+        """Cross-tabulate errors against the features.
+
+        Numeric features are summarized (count, mean, std, ...) per error group;
+        categorical features get an error rate per category. When
+        ``estimator_name`` is given (only valid with `from_poniard`), only the
+        top ``n_features`` by permutation importance are analyzed, computed on
+        the same cross-validation folds the Poniard estimator used.
 
         Parameters
         ----------
         errors_idx :
             Index of ranked errors.
         X :
-            Features array. Not needed if using `ErrorAnalyzer.from_poniard`.
+            Features array.
+        y :
+            Target. Required when `estimator_name` is used to compute
+            permutation importances.
         features :
-            Array of features to analyze. If `None`, all features will be analyzed.
+            Array of features to analyze. If `None`, all features will be
+            analyzed (unless `estimator_name` is given).
         estimator_name :
-            Only valid if using `ErrorAnalyzer.from_poniard`. Allows using an estimator to
-            compute permutation importances and analyzing only the top `n_features`.
+            Only valid if using `ErrorAnalyzer.from_poniard`. Allows using an
+            estimator to compute permutation importances and analyzing only the
+            top `n_features`.
         n_features :
-            How many features to analyze based on permutation importances.
+            How many features to analyze based on permutation importances. A
+            float between 0 and 1 is interpreted as a fraction of all features.
 
         Returns
         -------
         dict[str, pd.DataFrame]
             Per feature summary.
         """
+        if X is None:
+            raise ValueError("`X` must be provided.")
         if self._has_poniard:
-            X = self._poniard.X
             feature_types = self._poniard.feature_types.items()
         else:
             feature_types = (
                 PoniardPreprocessor(task="placeholder")
                 .build(X, np.zeros((X.shape[0],)))
                 .feature_types
+                .items()
             )
         inverted_feature_types = {}
         for k, v in feature_types:
             for i in v:
                 inverted_feature_types[i] = k
-        X = pd.DataFrame(X).assign(error=lambda x: x.index.isin(errors_idx).astype(int))
+        X = pd.DataFrame(X)
+        error_mask = X.index.isin(errors_idx).astype(int)
+        X = X.assign(error=error_mask)
+        columns = [col for col in X.columns if col != "error"]
 
         if features:
-            most_important_idx = []
+            features_idx = {
+                i
+                for i, col in enumerate(columns)
+                if col in features or i in features
+            }
         elif estimator_name:
-            features = []
-            model = self._poniard[estimator_name]
-            X_train, X_test, y_train, y_test = self._poniard._train_test_split_from_cv()
-            model.fit(X_train, y_train)
-            scoring = self._poniard._first_scorer(sklearn_scorer=True)
-            random_state = self._poniard.random_state
-            importances = permutation_importance(
-                model,
-                X_test,
-                y_test,
-                n_repeats=10,
-                scoring=scoring,
-                random_state=random_state,
-            )
-            sorted_importances_idx = importances.importances_mean.argsort()[::-1]
+            if not self._has_poniard:
+                raise ValueError(
+                    "`estimator_name` is only valid when using `from_poniard`."
+                )
+            if y is None:
+                raise ValueError("`y` must be provided when `estimator_name` is used.")
+            importances = self._compute_permutation_importances(X[columns], y, estimator_name)
+            sorted_importances_idx = importances.argsort()[::-1]
             if n_features is None:
                 n_features = 0.5
             if isinstance(n_features, float):
                 assert 0 <= n_features <= 1
-                n_features = round(n_features * X.shape[1])
-            most_important_idx = sorted_importances_idx[:n_features].tolist()
+                n_features = round(n_features * len(columns))
+            features_idx = set(sorted_importances_idx[: max(1, n_features)].tolist())
         else:
-            features = X.columns
-            most_important_idx = []
+            features_idx = set(range(len(columns)))
+
         summary = {}
-        for i, feature in enumerate(X.columns):
-            if (i in most_important_idx or feature in features) and feature != "error":
-                current_feature_type = inverted_feature_types[feature]
-                if current_feature_type == "numeric":
-                    feature_summary = X.groupby("error")[feature].describe()
-                else:
-                    feature_summary = (
-                        X.groupby("error")[feature]
-                        .value_counts(normalize=True, dropna=False)
-                        .rename("data")
-                        .reset_index(feature)
-                        .pivot(columns=feature, values="data")
-                    )
-                summary[feature] = feature_summary
+        for i, col in enumerate(columns):
+            if i not in features_idx:
+                continue
+            current_feature_type = inverted_feature_types.get(col, "numeric")
+            if current_feature_type == "numeric":
+                summary[col] = X.groupby("error")[col].describe()
+            else:
+                crosstab = pd.crosstab(X[col], X["error"], dropna=False)
+                crosstab = crosstab.reindex(columns=[0, 1], fill_value=0)
+                crosstab.columns = ["correct", "errors"]
+                total = crosstab["correct"] + crosstab["errors"]
+                crosstab = crosstab.assign(
+                    error_rate=(
+                        crosstab["errors"] / total.replace(0, np.nan)
+                    ).fillna(0)
+                )
+                summary[col] = crosstab
         return summary
+
+    def _compute_permutation_importances(
+        self, X, y, estimator_name: str, n_repeats: int = 10
+    ) -> np.ndarray:
+        """Compute permutation importances averaged over the Poniard CV folds."""
+        model = self._poniard[estimator_name]
+        scoring = self._poniard._first_scorer(sklearn_scorer=True)
+        random_state = self._poniard.random_state
+        cv = self._poniard.cv
+        splitter = getattr(cv, "split", None)
+        if splitter is None:
+            train_idx, test_idx = train_test_split(
+                np.arange(len(X)), test_size=0.2, random_state=random_state
+            )
+            folds = [(train_idx, test_idx)]
+        else:
+            folds = list(cv.split(X, y))
+        per_fold = []
+        for train_idx, test_idx in folds:
+            model.fit(self._subset(X, train_idx), self._subset(y, train_idx))
+            result = permutation_importance(
+                model,
+                self._subset(X, test_idx),
+                self._subset(y, test_idx),
+                n_repeats=n_repeats,
+                scoring=scoring,
+                random_state=random_state,
+            )
+            per_fold.append(result.importances_mean)
+        return np.mean(per_fold, axis=0)
+
+    @staticmethod
+    def _subset(data, idx):
+        """Index rows of a DataFrame/Series/ndarray by positional index."""
+        if isinstance(data, (pd.DataFrame, pd.Series)):
+            return data.iloc[idx]
+        return data[idx]
+
+    def analyze(
+        self,
+        X: np.ndarray | pd.DataFrame,
+        y: np.ndarray | pd.Series | pd.DataFrame,
+        estimator_names: str | Sequence[str] | None = None,
+        features: Sequence[str | int] | None = None,
+        n_features: int | float | None = None,
+        reg_bins: int = 5,
+        error_quantile: float = 0.1,
+    ) -> dict:
+        """Run the full error-analysis workflow and return a single report.
+
+        Convenience wrapper that computes ranked errors per estimator, the merged
+        cross-estimator view and the error distributions over the target and the
+        features, packaged into one dict.
+
+        Parameters
+        ----------
+        X :
+            Features.
+        y :
+            Ground truth target.
+        estimator_names :
+            Estimators to analyze. If None, the estimators selected at
+            `from_poniard` time are used.
+        features :
+            Subset of features to analyze. If None, all features are analyzed.
+        n_features :
+            Number of features to analyze based on permutation importances
+            (only used when the full feature set is not selected explicitly).
+        reg_bins :
+            Number of bins for regression targets. Default 5.
+        error_quantile :
+            Fraction of worst residuals kept as errors for regression tasks.
+            Default 0.1.
+
+        Returns
+        -------
+        dict
+            Report with keys ``ranked_errors`` (dict of DataFrames),
+            ``merged_errors`` (DataFrame), ``summary`` (per-estimator error
+            counts and rates), ``by_target`` (DataFrame) and ``by_feature``
+            (dict of DataFrames).
+        """
+        if estimator_names is not None:
+            self.estimator_names = element_to_list_maybe(estimator_names)
+        ranked = self.rank_errors(X=X, y=y, error_quantile=error_quantile)
+        if isinstance(ranked, pd.DataFrame):
+            ranked = {"model": ranked}
+        merged = self.merge_errors(ranked)
+        by_target = self.analyze_target(
+            errors_idx=merged.index, y=y, reg_bins=reg_bins
+        )
+        by_feature = self.analyze_features(
+            errors_idx=merged.index,
+            X=X,
+            y=y,
+            features=features,
+            n_features=n_features,
+        )
+        summary = pd.DataFrame(
+            {
+                estimator: {
+                    "n_errors": len(frame),
+                    "error_rate": len(frame) / len(y),
+                    "mean_error": float(frame["error"].mean()),
+                }
+                for estimator, frame in ranked.items()
+            }
+        ).T
+        return {
+            "ranked_errors": ranked,
+            "merged_errors": merged,
+            "summary": summary,
+            "by_target": by_target,
+            "by_feature": by_feature,
+        }
 
     def __repr__(self):
         return non_default_repr(self)

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.datasets import make_multilabel_classification, make_regression
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.multiclass import OneVsRestClassifier
+
+from poniard import PoniardClassifier, PoniardRegressor
+from poniard.error_analysis import ErrorAnalyzer
+
+N = 60
+
+
+@pytest.fixture
+def binary_data():
+    X = pd.DataFrame(
+        {
+            "a": np.random.normal(size=N),
+            "b": np.random.normal(size=N),
+            "c": np.random.choice(["x", "y", "z"], size=N),
+        }
+    )
+    y = pd.Series(np.random.choice([0, 1], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression()}, cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    return clf, X, y
+
+
+@pytest.fixture
+def multiclass_data():
+    X = pd.DataFrame(
+        {
+            "a": np.random.normal(size=N),
+            "b": np.random.normal(size=N),
+        }
+    )
+    y = pd.Series(np.random.choice([0, 1, 2], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)},
+        cv=2,
+        random_state=0,
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    return clf, X, y
+
+
+@pytest.fixture
+def multilabel_data():
+    X, y = make_multilabel_classification(
+        n_samples=N, n_features=3, n_classes=3, random_state=0
+    )
+    X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
+    clf = PoniardClassifier(
+        estimators={"lr": OneVsRestClassifier(LogisticRegression(max_iter=5000))},
+        cv=2,
+        random_state=0,
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    return clf, X, y
+
+
+@pytest.fixture
+def reg_data():
+    X = pd.DataFrame(
+        {
+            "a": np.random.normal(size=N),
+            "b": np.random.normal(size=N),
+        }
+    )
+    y = pd.Series(np.random.normal(size=N))
+    reg = PoniardRegressor(
+        estimators={"lr": LinearRegression()}, cv=2, random_state=0
+    )
+    reg.setup(X, y)
+    reg.fit(X, y)
+    return reg, X, y
+
+
+@pytest.fixture
+def multioutput_reg_data():
+    X, y = make_regression(
+        n_samples=N, n_features=3, n_targets=2, random_state=0
+    )
+    X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
+    y = pd.DataFrame(y, columns=[f"t{i}" for i in range(y.shape[1])])
+    reg = PoniardRegressor(
+        estimators={"lr": LinearRegression()}, cv=2, random_state=0
+    )
+    reg.setup(X, y)
+    reg.fit(X, y)
+    return reg, X, y
+
+
+def _make_ea(clf, estimator_names: str | Sequence[str] = "lr"):
+    return ErrorAnalyzer.from_poniard(clf, estimator_names)
+
+
+class TestFromPoniard:
+    def test_construction(self, binary_data):
+        clf, _, _ = binary_data
+        ea = _make_ea(clf)
+        assert ea._has_poniard
+        assert ea.task == "classification"
+        assert ea.estimator_names == ["lr"]
+        assert ea.type_of_target == "binary"
+
+    def test_construction_multiple_estimators(self, binary_data):
+        clf, _, _ = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        assert ea.estimator_names == ["lr", "DummyClassifier"]
+
+    def test_standalone_construction(self):
+        ea = ErrorAnalyzer(task="classification")
+        assert not ea._has_poniard
+        assert ea.task == "classification"
+
+
+class TestRankErrors:
+    def test_binary(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        result = ea.rank_errors(X=X, y=y)
+        assert isinstance(result, dict)
+        assert "lr" in result
+        assert isinstance(result["lr"], pd.DataFrame)
+        assert "error" in result["lr"].columns
+
+    def test_multiclass(self, multiclass_data):
+        clf, X, y = multiclass_data
+        ea = _make_ea(clf)
+        result = ea.rank_errors(X=X, y=y)
+        assert "proba_0" in result["lr"].columns
+
+    def test_multilabel(self, multilabel_data):
+        clf, X, y = multilabel_data
+        ea = _make_ea(clf)
+        result = ea.rank_errors(X=X, y=y)
+        assert result["lr"].shape[1] >= 3
+        assert "error" in result["lr"].columns
+
+    def test_continuous(self, reg_data):
+        clf, X, y = reg_data
+        ea = _make_ea(clf)
+        result = ea.rank_errors(X=X, y=y)
+        assert "prediction" in result["lr"].columns
+        assert "error" in result["lr"].columns
+
+    def test_continuous_multioutput(self, multioutput_reg_data):
+        clf, X, y = multioutput_reg_data
+        ea = _make_ea(clf)
+        result = ea.rank_errors(X=X, y=y)
+        assert "prediction_0" in result["lr"].columns
+        assert "error" in result["lr"].columns
+
+    def test_exclude_correct_false(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        result_excluded = ea.rank_errors(X=X, y=y, exclude_correct=True)
+        result_all = ea.rank_errors(X=X, y=y, exclude_correct=False)
+        assert len(result_all["lr"]) >= len(result_excluded["lr"])
+
+    def test_regression_error_quantile(self, reg_data):
+        clf, X, y = reg_data
+        ea = _make_ea(clf)
+        strict = ea.rank_errors(X=X, y=y, error_quantile=0.1)
+        lax = ea.rank_errors(X=X, y=y, error_quantile=0.5)
+        assert len(lax["lr"]) > len(strict["lr"])
+        assert lax["lr"]["error"].max() >= strict["lr"]["error"].max()
+
+    def test_requires_X_and_y(self, binary_data):
+        clf, _, _ = binary_data
+        ea = _make_ea(clf)
+        with pytest.raises(ValueError, match="X and y"):
+            ea.rank_errors()
+
+    def test_standalone_mode(self):
+        n = 30
+        y = np.array(
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        )
+        predictions = np.zeros(n, dtype=int)
+        probas = np.array([[0.9, 0.1]] * 15 + [[0.6, 0.4]] * 15)
+        ea = ErrorAnalyzer(task="classification")
+        result = ea.rank_errors(y=y, predictions=predictions, probas=probas)
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 15
+        assert np.allclose(result["error"].values, 0.6)
+
+
+class TestMergeErrors:
+    def test_merge(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        assert isinstance(merged, pd.DataFrame)
+        assert "mean_error" in merged.columns
+        assert "freq" in merged.columns
+        assert "estimators" in merged.columns
+        assert merged["freq"].max() <= len(errors)
+
+    def test_merge_single_dataframe(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)["lr"]
+        merged = ErrorAnalyzer.merge_errors(errors)
+        assert isinstance(merged, pd.DataFrame)
+        assert merged["freq"].max() == 1
+
+
+class TestAnalyzeTarget:
+    def test_classification(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        analysis = ea.analyze_target(errors_idx=merged.index, y=y)
+        assert isinstance(analysis, pd.DataFrame)
+        assert not analysis.empty
+        assert {"error_count", "target_count", "error_rate"} <= set(analysis.columns)
+
+    def test_regression(self, reg_data):
+        clf, X, y = reg_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        analysis = ea.analyze_target(errors_idx=merged.index, y=y)
+        assert isinstance(analysis, pd.DataFrame)
+        assert not analysis.empty
+        assert {"error_count", "target_count", "error_rate"} <= set(analysis.columns)
+
+    def test_error_rate_is_count_ratio(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        analysis = ea.analyze_target(errors_idx=merged.index, y=y)
+        expected = analysis["error_count"] / analysis["target_count"]
+        assert np.allclose(analysis["error_rate"].values, expected.values)
+
+    def test_requires_y(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        with pytest.raises(ValueError, match="y"):
+            ea.analyze_target(errors_idx=merged.index)
+
+
+class TestAnalyzeFeatures:
+    def test_all_features(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(errors_idx=merged.index, X=X)
+        assert isinstance(summary, dict)
+        assert len(summary) > 0
+        for feature_name, feature_summary in summary.items():
+            assert isinstance(feature_summary, pd.DataFrame)
+
+    def test_with_feature_subset_by_name(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(
+            errors_idx=merged.index, X=X, features=["a", "b"]
+        )
+        assert set(summary.keys()) == {"a", "b"}
+
+    def test_with_feature_subset_by_index(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(errors_idx=merged.index, X=X, features=[0, 1])
+        assert set(summary.keys()) == {"a", "b"}
+
+    def test_with_estimator_name(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(
+            errors_idx=merged.index,
+            X=X,
+            y=y,
+            estimator_name="lr",
+            n_features=2,
+        )
+        assert isinstance(summary, dict)
+        assert len(summary) <= X.shape[1]
+
+    def test_with_estimator_name_n_features_float(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(
+            errors_idx=merged.index,
+            X=X,
+            y=y,
+            estimator_name="lr",
+            n_features=0.5,
+        )
+        assert isinstance(summary, dict)
+
+    def test_numeric_feature_summary_structure(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(errors_idx=merged.index, X=X)
+        assert "count" in summary["a"].columns
+        assert "mean" in summary["a"].columns
+
+    def test_categorical_feature_has_error_rate(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        summary = ea.analyze_features(errors_idx=merged.index, X=X)
+        assert "c" in summary
+        assert {"correct", "errors", "error_rate"} <= set(summary["c"].columns)
+
+    def test_requires_X(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        with pytest.raises(ValueError, match="X"):
+            ea.analyze_features(errors_idx=merged.index)
+
+    def test_estimator_name_requires_y(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        with pytest.raises(ValueError, match="y"):
+            ea.analyze_features(
+                errors_idx=merged.index, X=X, estimator_name="lr"
+            )
+
+    def test_estimator_name_requires_from_poniard(self, reg_data):
+        clf, X, y = reg_data
+        ea = ErrorAnalyzer(task="regression")
+        with pytest.raises(ValueError, match="from_poniard"):
+            ea.analyze_features(
+                errors_idx=pd.Index([0]), X=X, y=y, estimator_name="lr"
+            )
+
+
+class TestAnalyze:
+    def test_report_structure(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert set(report) == {
+            "ranked_errors",
+            "merged_errors",
+            "summary",
+            "by_target",
+            "by_feature",
+        }
+        assert "lr" in report["ranked_errors"]
+        assert isinstance(report["merged_errors"], pd.DataFrame)
+        assert not report["by_target"].empty
+        assert len(report["by_feature"]) > 0
+
+    def test_summary_error_rates(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        report = ea.analyze(X=X, y=y)
+        assert "error_rate" in report["summary"].columns
+        expected = len(report["ranked_errors"]["lr"]) / len(y)
+        assert report["summary"].loc["lr", "error_rate"] == pytest.approx(expected)
+
+    def test_estimator_names_override(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        report = ea.analyze(X=X, y=y, estimator_names="lr")
+        assert set(report["ranked_errors"]) == {"lr"}
+
+    def test_regression_report(self, reg_data):
+        clf, X, y = reg_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert "error_rate" in report["summary"].columns
+        assert not report["by_target"].empty
+        assert len(report["by_feature"]) > 0
+
+
+def test_repr():
+    ea = ErrorAnalyzer(task="classification")
+    r = repr(ea)
+    assert "ErrorAnalyzer" in r

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -256,6 +256,18 @@ class TestAnalyzeTarget:
         with pytest.raises(ValueError, match="y"):
             ea.analyze_target(errors_idx=merged.index)
 
+    def test_known_error_region(self):
+        """Errors confined to one class must be surfaced by error_rate."""
+        y = pd.Series(["easy"] * 50 + ["hard"] * 50)
+        errors_idx = y.index[y == "hard"]
+        ea = ErrorAnalyzer(task="classification")
+        ea.type_of_target = "multiclass"
+        analysis = ea.analyze_target(errors_idx=errors_idx, y=y)
+        assert analysis.loc["hard", "error_count"] == 50
+        assert analysis.loc["hard", "error_rate"] == pytest.approx(1.0)
+        assert analysis.loc["easy", "error_count"] == 0
+        assert analysis.loc["easy", "error_rate"] == 0.0
+
 
 class TestAnalyzeFeatures:
     def test_all_features(self, binary_data):
@@ -359,6 +371,48 @@ class TestAnalyzeFeatures:
             ea.analyze_features(
                 errors_idx=pd.Index([0]), X=X, y=y, estimator_name="lr"
             )
+
+    def test_categorical_known_error_region(self):
+        """Errors confined to one category must surface as a high error_rate."""
+        n = 100
+        X = pd.DataFrame(
+            {
+                "num": np.random.normal(size=n),
+                "cat": np.array(["a", "b"] * 50),
+            }
+        )
+        errors_idx = X.index[X["cat"] == "b"]
+        ea = ErrorAnalyzer(task="classification")
+        summary = ea.analyze_features(errors_idx=errors_idx, X=X)
+        cat_table = summary["cat"]
+        assert cat_table.loc["b", "errors"] == 50
+        assert cat_table.loc["b", "error_rate"] == pytest.approx(1.0)
+        assert cat_table.loc["a", "errors"] == 0
+        assert cat_table.loc["a", "error_rate"] == 0.0
+
+    def test_numeric_known_error_region(self):
+        """Errors confined to one end of a numeric range must separate the
+        mean of the two error groups."""
+        X = pd.DataFrame({"num": np.linspace(-5, 5, 100)})
+        errors_idx = X.index[X["num"] > 0]
+        ea = ErrorAnalyzer(task="classification")
+        summary = ea.analyze_features(errors_idx=errors_idx, X=X)
+        num_table = summary["num"]
+        assert num_table.loc[1, "mean"] > 0
+        assert num_table.loc[0, "mean"] < 0
+
+    def test_permutation_importances_deterministic(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        errors = ea.rank_errors(X=X, y=y)
+        merged = ErrorAnalyzer.merge_errors(errors)
+        first = ea.analyze_features(
+            errors_idx=merged.index, X=X, y=y, estimator_name="lr", n_features=2
+        )
+        second = ea.analyze_features(
+            errors_idx=merged.index, X=X, y=y, estimator_name="lr", n_features=2
+        )
+        assert set(first) == set(second)
 
 
 class TestAnalyze:


### PR DESCRIPTION
## Summary

Overhauls `ErrorAnalyzer` to make it a first-class feature (roadmap items **1.2** — fix bugs in differentiated modules, **3.1** — test coverage, **3.2** — data passing, **3.3** — documentation).

## Changes

### Bug fixes
- `analyze_features` called `_train_test_split_from_cv()` with no `X, y` (would `NameError`); now passes them explicitly.
- Positional-vs-name index mismatch in `analyze_features`: feature selection is now unified on positional indices; a positional int is never compared to a column name.
- `_compute_predictions`/`rank_errors`/`analyze_target` reached into `self._poniard.X/y` which were never stored on the estimator; they now require `X`/`y` explicitly (ErrorAnalyzer stays stateless).
- `_rank_errors_continuous_multioutput` broadcast bug (`np.std(y, axis=0)` returned a Series → pandas alignment failure).
- Multiclass ranking: pandas upcast `row['y']` to float → `KeyError: 'proba_2.0'`.
- Standalone `analyze_features` iterated `.feature_types` dict without `.items()`.

### Redesign
- **Return contract**: `rank_errors` / `merge_errors` return plain DataFrames (dropped the `{"values", "idx"}` wrapper). `merge_errors` accepts a dict of DataFrames or a single DataFrame.
- **Regression error definition**: samples flagged by `|residual| > (1 - error_quantile)` quantile threshold (default worst 10%), replacing the global ±1 std band. Per-target thresholds for multioutput.
- **Fold-consistent importances**: permutation importances averaged over the Poniard estimator's CV folds instead of a random 80/20 split.
- **Interpretation**: `analyze_target` returns `error_count` / `target_count` / `error_rate` per class/bin (always a DataFrame; `as_ratio`/`wrt_target` removed). Categorical features in `analyze_features` get an error-rate-per-category table.
- **Orchestrator**: new `analyze(X, y, ...)` returns a single report with `ranked_errors`, `merged_errors`, `summary`, `by_target`, `by_feature`.

### Tests & docs
- New `tests/test_error_analysis.py` with 33 tests (all target types, error paths, report structure, quantile threshold).
- `ErrorAnalyzer` section added to README.

## Breaking changes
- `rank_errors`/`merge_errors` return DataFrames instead of `{"values", "idx"}` dicts.
- `analyze_target` drops `as_ratio` / `wrt_target`; now always returns a DataFrame with `error_rate`.
- `analyze_features` requires `X` (and `y` when `estimator_name` is used).
- `rank_errors` requires `X` and `y` when built via `from_poniard`.

## Tests
`pytest` — 128 passed (95 existing + 33 new).