### PR TITLE
refactor: track fitted pipelines by name instead of id (roadmap 1.3)

### DIFF
--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -380,7 +380,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             name: self._make_pipeline(name, estimator)
             for name, estimator in estimators.items()
         }
-        self._fitted_pipeline_ids = []
+        self._fitted_pipeline_names = set()
         return pipelines
 
     def _add_dummy_estimators(self, estimators: dict):
@@ -476,7 +476,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         filtered_pipelines = {
             name: pipeline
             for name, pipeline in self.pipelines.items()
-            if id(pipeline) not in self._fitted_pipeline_ids
+            if name not in self._fitted_pipeline_names
         }
         pbar = tqdm(filtered_pipelines.items(), leave=self._tqdm_leave)
         for i, (name, pipeline) in enumerate(pbar):
@@ -497,7 +497,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                     n_jobs=self.n_jobs,
                 )
             results.update({name: result})
-            self._fitted_pipeline_ids.append(id(pipeline))
+            self._fitted_pipeline_names.add(name)
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
         if hasattr(self, "_experiment_results"):

--- a/tests/test_fitted_tracking.py
+++ b/tests/test_fitted_tracking.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+
+from poniard import PoniardClassifier
+
+Y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1])
+
+
+def _clf():
+    x = pd.DataFrame(np.random.normal(size=(len(Y), 5)))
+    return PoniardClassifier(
+        estimators=[LogisticRegression()], cv=2, random_state=0
+    ), x
+
+
+def test_fit_tracks_pipeline_names():
+    clf, x = _clf()
+    clf.setup(x, Y)
+    clf.fit(x, Y)
+    assert clf._fitted_pipeline_names == set(clf.pipelines)
+
+
+def test_add_estimators_does_not_clear_fitted_set():
+    clf, x = _clf()
+    clf.setup(x, Y)
+    clf.fit(x, Y)
+    fitted_before = clf._fitted_pipeline_names.copy()
+    clf.add_estimators({"rf": LogisticRegression()})
+    assert clf._fitted_pipeline_names == fitted_before
+    clf.fit(x, Y)
+    assert "rf" in clf._fitted_pipeline_names
+
+
+def test_reassign_types_clears_fitted_set():
+    clf, x = _clf()
+    clf.setup(x, Y)
+    clf.fit(x, Y)
+    assert clf._fitted_pipeline_names
+    clf.reassign_types(numeric=[0])
+    assert clf._fitted_pipeline_names == set()
+
+
+def test_add_preprocessing_step_clears_fitted_set():
+    clf, x = _clf()
+    clf.setup(x, Y)
+    clf.fit(x, Y)
+    assert clf._fitted_pipeline_names
+    clf.add_preprocessing_step(("scaler", StandardScaler()))
+    assert clf._fitted_pipeline_names == set()
+
+
+def test_remove_estimators_leaves_remaining_fitted():
+    clf, x = _clf()
+    clf.setup(x, Y)
+    clf.fit(x, Y)
+    clf.remove_estimators(["DummyClassifier"])
+    assert "LogisticRegression" in clf._fitted_pipeline_names


### PR DESCRIPTION
## Summary

Roadmap **1.3** — replace `id()`-based fitted-pipeline tracking with pipeline names.

## Changes

- `_fitted_pipeline_ids` (a list of Python `id()`s) → `_fitted_pipeline_names` (a set of pipeline names, i.e. the keys of `self.pipelines`).
- Names are the stable user-facing identity; Python `id()`s can be reused after garbage collection, which could make `fit` silently skip estimators.
- Rebuilds (`_build_pipelines`, used by `reassign_types` and `add_preprocessing_step`) clear the fitted set, so a re-fit after reconfiguring re-runs everything — verified by tests (roadmap Priority-5 requirement).

## Note on scope

The roadmap describes the id-based tracking as causing `fit` to *skip newly added estimators*. In the current code every `fit` rebuilds pipelines (which resets the tracking set), so `fit` always re-ran everything — the id list never actually accumulated across calls. This PR hardens the mechanism (names are stable) and is a prerequisite for **2.1** (de-duplicate `setup`/`fit`), which introduces idempotent re-fit semantics.

## Tests

New `tests/test_fitted_tracking.py` (5 tests): fit tracks names; `reassign_types` / `add_preprocessing_step` clear the set; `add_estimators` does not; `remove_estimators` leaves remaining names.

Full suite: 138 passed; `ruff` clean.