### PR TITLE
refactor: eliminate setup/fit duplication via _configure (roadmap 2.1)

### DIFF
--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -163,6 +163,21 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         PoniardBaseEstimator
             Self.
         """
+        self._configure(X, y, show_info)
+        return self
+
+    def _configure(self, X, y, show_info):
+        """Infer types, build preprocessing, pipelines and CV.
+
+        Shared by `setup` and `fit`. Re-running it with the same inputs
+        re-configures consistently, which keeps `setup(X, y)` → adjust →
+        `fit(X, y)` valid even after `reassign_types` / `add_preprocessing_step`.
+
+        Returns
+        -------
+        tuple
+            The converted `X` and `y`, which `fit` uses for cross-validation.
+        """
         if pl is not None and isinstance(X, (pl.DataFrame, pl.Series)):
             X = X.to_pandas()
         if pl is not None and isinstance(y, (pl.DataFrame, pl.Series)):
@@ -199,7 +214,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         self.pipelines = self._build_pipelines()
         self.cv = self._build_cv()
 
-        return self
+        return X, y
 
     def _print_setup_info(self):
         type_ = self.target_info["type_"]
@@ -430,46 +445,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         PoniardBaseEstimator
             Self.
         """
-        # Input conversion
-        if pl is not None and isinstance(X, (pl.DataFrame, pl.Series)):
-            X = X.to_pandas()
-        if pl is not None and isinstance(y, (pl.DataFrame, pl.Series)):
-            y = y.to_pandas()
-        if not isinstance(X, (pd.DataFrame, pd.Series, np.ndarray)):
-            X = np.array(X)
-        if not isinstance(y, (pd.DataFrame, pd.Series, np.ndarray)):
-            y = np.array(y)
-
-        # Type inference and metadata
-        self.show_info = show_info
-        self.target_info = get_target_info(y, self.poniard_task)
-        if self.target_info["type_"] == "multiclass-multioutput":
-            raise NotImplementedError(
-                "multiclass-multioutput targets are not supported as "
-                "no sklearn metrics support them."
-            )
-        if self.metrics:
-            self.metrics = element_to_list_maybe(self.metrics)
-        else:
-            self.metrics = self._build_metrics()
-
-        # Preprocessing
-        if self.preprocess:
-            if self.custom_preprocessor and not isinstance(
-                self.custom_preprocessor, PoniardPreprocessor
-            ):
-                self.preprocessor = self.custom_preprocessor
-            else:
-                self.preprocessor = self._build_preprocessor(X, y)
-            self._pass_instance_attrs(self.preprocessor)
-            self._ensure_pandas_output(self.preprocessor)
-
-        if self.show_info:
-            self._print_setup_info()
-
-        # Build pipelines and CV
-        self.pipelines = self._build_pipelines()
-        self.cv = self._build_cv()
+        X, y = self._configure(X, y, show_info)
 
         # Cross-validate
         results = {}

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -687,6 +687,34 @@ class TestEdgeCases:
         # Pipelines dict should have the same keys after fit
         assert set(pipeline_ids_before.keys()) == set(clf.pipelines.keys())
 
+    def test_setup_and_fit_configure_identically(self):
+        """setup() and fit() must produce the same introspection surface
+        (feature_types, metrics, preprocessor and pipelines), so the
+        setup-then-adjust-then-fit flow is preserved."""
+        n = 60
+        X = pd.DataFrame(
+            {
+                "num": np.random.normal(size=n),
+                "cat": np.random.choice(["a", "b", "c"], size=n),
+            }
+        )
+        y = np.array([0, 1] * (n // 2))
+
+        setup_clf = PoniardClassifier(
+            estimators=[LogisticRegression()], cv=2, random_state=42
+        )
+        setup_clf.setup(X, y)
+
+        fit_clf = PoniardClassifier(
+            estimators=[LogisticRegression()], cv=2, random_state=42
+        )
+        fit_clf.fit(X, y)
+
+        assert setup_clf.feature_types == fit_clf.feature_types
+        assert setup_clf.metrics == fit_clf.metrics
+        assert set(setup_clf.pipelines) == set(fit_clf.pipelines)
+        assert isinstance(setup_clf.preprocessor, type(fit_clf.preprocessor))
+
     def test_random_state_propagation(self):
         """random_state should be propagated to estimators that support it."""
         n = 50


### PR DESCRIPTION
## Summary

Roadmap **2.1** — eliminate the ~40 lines of duplicated configure logic in `setup`/`fit` while keeping the two-step UX.

## Changes

- Extracted the shared logic (input conversion, `target_info`, metrics resolution, preprocessor build, info printing, pipeline build, CV build) into a private `_configure(X, y, show_info)`.
- `setup()` calls `_configure` and returns `self` — the introspection surface (`feature_types`, `preprocessor`, `pipelines`, `metrics`, `cv`) is still fully built for inspection/adjustment before fitting.
- `fit()` calls `_configure`, which returns the converted `X, y` (needed for `cross_validate`), then proceeds to cross-validate.
- Behavior is identical to before; the duplication is gone.

## Note on "idempotent"

The roadmap describes `_configure` as idempotent ("re-running with the same inputs is a no-op"). True no-op idempotency would require storing `X`/`y` on the estimator to detect unchanged inputs — a memory/serialization regression we deliberately avoided in the error-analysis work. So `_configure` re-configures on each call, exactly as `setup`/`fit` did before.

## Tests

- New `test_setup_and_fit_configure_identically`: estimators built via `setup` vs `fit` produce identical `feature_types`, `metrics`, pipeline names and preprocessor type.
- Full suite: 139 passed; `ruff` clean.