### PR TITLE
feat: robustness pass - save/load, pristine thresholds, name-based results (roadmap 4.1, 4.3, 4.4)

### DIFF
--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from typing import Sequence
 
+import joblib
 import numpy as np
 import pandas as pd
 from sklearn.base import ClassifierMixin, RegressorMixin, TransformerMixin, clone
@@ -883,6 +884,36 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 raise ValueError("X and y must be provided when retrain=True.")
             model.fit(X, y)
         return model
+
+    def save(self, path: str | os.PathLike) -> None:
+        """Save the fitted estimator to disk with joblib.
+
+        Use `PoniardClassifier.load` / `PoniardRegressor.load` to restore it.
+        A fitted estimator round-trips `fit` → `save` → `load` → `get_results`
+        without losing results.
+
+        Parameters
+        ----------
+        path :
+            Where to write the estimator.
+        """
+        joblib.dump(self, path)
+
+    @classmethod
+    def load(cls, path: str | os.PathLike) -> PoniardBaseEstimator:
+        """Load an estimator saved with `save`.
+
+        Parameters
+        ----------
+        path :
+            Location of the saved estimator.
+
+        Returns
+        -------
+        PoniardBaseEstimator
+            The restored estimator.
+        """
+        return joblib.load(path)
 
     def _train_test_split_from_cv(self, X, y):
         """Split data in a 80/20 fashion following the cross-validation strategy defined in the constructor."""

--- a/poniard/estimators/results.py
+++ b/poniard/estimators/results.py
@@ -66,8 +66,10 @@ class ResultsMixin:
         ]
         means = results.apply(lambda x: np.mean(np.stack(x.values), axis=1))
         stds = results.apply(lambda x: np.std(np.stack(x.values), axis=1))
-        means = means[list(means.columns[2:]) + ["fit_time", "score_time"]]
-        stds = stds[list(stds.columns[2:]) + ["fit_time", "score_time"]]
+        time_columns = ["fit_time", "score_time"]
+        metric_columns = [c for c in means.columns if c not in time_columns]
+        means = means[metric_columns + time_columns]
+        stds = stds[metric_columns + time_columns]
         self._means = means.sort_values(means.columns[0], ascending=False)
         self._stds = stds.reindex(self._means.index)
 

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -349,10 +349,16 @@ class PoniardPreprocessor:
         categorical_low: list = []
         datetime_cols: list = []
 
-        if not isinstance(self.cardinality_threshold, int):
-            self.cardinality_threshold = int(self.cardinality_threshold * X.shape[0])
-        if not isinstance(self.numeric_threshold, int):
-            self.numeric_threshold = int(self.numeric_threshold * X.shape[0])
+        cardinality_threshold = (
+            self.cardinality_threshold
+            if isinstance(self.cardinality_threshold, int)
+            else int(self.cardinality_threshold * X.shape[0])
+        )
+        numeric_threshold = (
+            self.numeric_threshold
+            if isinstance(self.numeric_threshold, int)
+            else int(self.numeric_threshold * X.shape[0])
+        )
 
         if isinstance(X, pd.DataFrame):
             for col in X.columns:
@@ -362,15 +368,15 @@ class PoniardPreprocessor:
                 if pd.api.types.is_datetime64_any_dtype(dtype):
                     datetime_cols.append(col)
                 elif pd.api.types.is_numeric_dtype(dtype):
-                    if nunique > self.numeric_threshold:
+                    if nunique > numeric_threshold:
                         numeric.append(col)
-                    elif nunique > self.cardinality_threshold:
+                    elif nunique > cardinality_threshold:
                         categorical_high.append(col)
                     else:
                         categorical_low.append(col)
                 else:
                     # strings, objects, categorical, boolean
-                    if nunique > self.cardinality_threshold:
+                    if nunique > cardinality_threshold:
                         categorical_high.append(col)
                     else:
                         categorical_low.append(col)
@@ -381,14 +387,14 @@ class PoniardPreprocessor:
                 if np.issubdtype(col.dtype, np.datetime64):
                     datetime_cols.append(i)
                 elif np.issubdtype(col.dtype, np.number):
-                    if nunique > self.numeric_threshold:
+                    if nunique > numeric_threshold:
                         numeric.append(i)
-                    elif nunique > self.cardinality_threshold:
+                    elif nunique > cardinality_threshold:
                         categorical_high.append(i)
                     else:
                         categorical_low.append(i)
                 else:
-                    if nunique > self.cardinality_threshold:
+                    if nunique > cardinality_threshold:
                         categorical_high.append(i)
                     else:
                         categorical_low.append(i)

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -184,6 +184,23 @@ class TestTypeInference:
         preprocessor.build(X=X, y=y, task="classification")
         assert "many_ints" in preprocessor.feature_types["numeric"]
 
+    def test_float_thresholds_stay_pristine_after_build(self):
+        """build() must not convert the float thresholds to ints in place, so a
+        second build() on different data uses the same constructor values."""
+        preprocessor = PoniardPreprocessor(
+            numeric_threshold=0.5,
+            cardinality_threshold=0.5,
+        )
+        X1 = pd.DataFrame({"a": np.arange(20)})
+        y = np.zeros(20, dtype=int)
+        preprocessor.build(X=X1, y=y, task="classification")
+        assert preprocessor.numeric_threshold == 0.5
+        assert preprocessor.cardinality_threshold == 0.5
+        X2 = pd.DataFrame({"a": np.arange(100)})
+        preprocessor.build(X=X2, y=y, task="classification")
+        assert preprocessor.numeric_threshold == 0.5
+        assert preprocessor.cardinality_threshold == 0.5
+
 
 # ===========================================================================
 # 2. Preprocessing tests

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,96 @@
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LinearRegression, LogisticRegression
+
+from poniard import PoniardClassifier, PoniardRegressor
+
+
+def _clf_data():
+    n = 60
+    X = pd.DataFrame(
+        {
+            "a": np.random.normal(size=n),
+            "b": np.random.normal(size=n),
+            "c": np.random.choice(["x", "y", "z"], size=n),
+        }
+    )
+    y = pd.Series(np.random.choice([0, 1], size=n))
+    return X, y
+
+
+def _reg_data():
+    X = pd.DataFrame(np.random.normal(size=(60, 3)), columns=["a", "b", "c"])
+    y = pd.Series(np.random.normal(size=60))
+    return X, y
+
+
+def test_save_load_round_trip_classifier(tmp_path):
+    X, y = _clf_data()
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression()], cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    results_before = clf.get_results()
+
+    path = tmp_path / "clf.joblib"
+    clf.save(path)
+    loaded = PoniardClassifier.load(path)
+
+    assert isinstance(loaded, PoniardClassifier)
+    pd.testing.assert_frame_equal(loaded.get_results(), results_before)
+    assert loaded._experiment_results.keys() == clf._experiment_results.keys()
+
+
+def test_save_load_round_trip_regressor(tmp_path):
+    X, y = _reg_data()
+    reg = PoniardRegressor(
+        estimators=[LinearRegression()], cv=2, random_state=0
+    )
+    reg.setup(X, y)
+    reg.fit(X, y)
+    results_before = reg.get_results()
+
+    path = tmp_path / "reg.joblib"
+    reg.save(path)
+    loaded = PoniardRegressor.load(path)
+
+    assert isinstance(loaded, PoniardRegressor)
+    pd.testing.assert_frame_equal(loaded.get_results(), results_before)
+
+
+def test_loaded_estimator_can_export_pipeline(tmp_path):
+    X, y = _clf_data()
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression()], cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    path = tmp_path / "clf.joblib"
+    clf.save(path)
+    loaded = PoniardClassifier.load(path)
+    model = loaded.get_estimator(
+        "LogisticRegression", retrain=True, X=X, y=y
+    )
+    assert len(model.predict(X)) == len(X)
+
+
+def test_save_load_after_tuning(tmp_path):
+    X, y = _clf_data()
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression()], cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    clf.tune_estimator(
+        "LogisticRegression",
+        X,
+        y,
+        grid={"LogisticRegression__C": [0.1, 1.0]},
+    )
+    clf.fit(X, y)
+    path = tmp_path / "tuned.joblib"
+    clf.save(path)
+    loaded = PoniardClassifier.load(path)
+    assert "LogisticRegression_tuned" in loaded.pipelines
+    assert loaded.get_results().shape[0] == 3


### PR DESCRIPTION
## Summary

Roadmap sequencing step 6 — robustness pass: **4.1** (`save`/`load`), **4.3** (pristine thresholds), **4.4** (name-based results columns).

## Changes

### 4.1 — `save` / `load`
- `PoniardBaseEstimator.save(path)` and classmethod `load(path)` using `joblib` (already a dependency).
- A fitted estimator round-trips `fit` → `save` → `load` → `get_results` without losing results. No `X`/`y` are stored on the estimator, so there is nothing extra to drop on save.

### 4.3 — stop stateful side effects in `_infer_dtypes`
- `_infer_dtypes` previously mutated `self.numeric_threshold` / `self.cardinality_threshold` from floats to ints as a side effect, so a second `build()` on different data silently used the converted ints.
- Thresholds are now resolved into local variables per call; constructor values stay pristine.

### 4.4 — decouple `_process_results` from `cross_validate` column order
- Replaced `list(means.columns[2:]) + ["fit_time", "score_time"]` (assumes the times are positional columns 0–1) with name-based selection (`metric_columns + time_columns`).

## Tests
- `tests/test_save_load.py`: classifier + regressor round-trip with identical `get_results`, loaded estimator can export a fitted pipeline, save after tuning.
- `test_meaningful.py`: float thresholds stay pristine across two `build()` calls.
- Full suite: 148 passed; `ruff` clean.