### PR TITLE
feat: polish the analysis layer - plot smoke tests, repr refactor, dashboard rename (roadmap 3.3, 3.4, 4.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ plotter.metrics()
 plotter.roc_curve()
 plotter.confusion_matrix("LogisticRegression")
 plotter.permutation_importance("LogisticRegression")
+
+# Single-figure dashboard: metric rankings, model comparison, ROC/confusion
+# matrix (or residuals for regression) and permutation importance in one view
+plotter.full_estimator_analysis("LogisticRegression")
 ```
 
 ## Error analysis

--- a/examples/02_error_analysis.ipynb
+++ b/examples/02_error_analysis.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Error analysis with Poniard\n",
+    "\n",
+    "Beyond a leaderboard, Poniard keeps going into *where and why* your models fail. `ErrorAnalyzer` ranks the worst samples and cross-tabulates them against the target and the features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.datasets import make_classification\n",
+    "from poniard import PoniardClassifier\n",
+    "from poniard.error_analysis import ErrorAnalyzer\n",
+    "\n",
+    "X, y = make_classification(\n",
+    "    n_samples=200, n_features=10, n_informative=5, random_state=42\n",
+    ")\n",
+    "clf = PoniardClassifier()\n",
+    "clf.fit(X, y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ea = ErrorAnalyzer.from_poniard(\n",
+    "    clf, estimator_names=[\"LogisticRegression\", \"RandomForestClassifier\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## One call: the full report\n",
+    "\n",
+    "`analyze` runs the whole workflow and packages it into a single report."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report = ea.analyze(X, y)\n",
+    "list(report)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# per-estimator: how many samples failed and the error rate\n",
+    "report[\"summary\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# per sample: how many estimators failed on it, and their average error\n",
+    "report[\"merged_errors\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The individual steps\n",
+    "\n",
+    "Rank the worst samples per estimator, then merge across estimators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranked = ea.rank_errors(X, y)\n",
+    "# worst samples for the RandomForest, ranked by how confidently wrong it is\n",
+    "ranked[\"RandomForestClassifier\"].head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged = ErrorAnalyzer.merge_errors(ranked)\n",
+    "merged.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where do the errors live?\n",
+    "\n",
+    "Errors per target class, including the error rate (the share of each class that is misclassified)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ea.analyze_target(errors_idx=merged.index, y=y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# per feature: numeric summaries by error group, error rate per category\n",
+    "ea.analyze_features(errors_idx=merged.index, X=X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feature-level analysis with permutation importance\n",
+    "\n",
+    "Restrict to the top features by permutation importance (computed on the same cross-validation folds Poniard used)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ea.analyze_features(\n",
+    "    errors_idx=merged.index, X=X, y=y,\n",
+    "    estimator_name=\"LogisticRegression\", n_features=3,\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from poniard.estimators.core import PoniardBaseEstimator
 from ..preprocessing import PoniardPreprocessor
 from ..utils.estimate import element_to_list_maybe, get_target_info
-from ..utils.utils import get_kwargs, non_default_repr
+from ..utils.utils import non_default_repr
 
 
 class ErrorAnalyzer:
@@ -44,7 +44,7 @@ class ErrorAnalyzer:
     """
 
     def __init__(self, task: str):
-        self._init_params = get_kwargs()
+        self._init_params = {k: v for k, v in locals().items() if k != "self"}
         self.task = task
         self._poniard: PoniardBaseEstimator | None = None
 

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -36,7 +36,7 @@ except ImportError:
 
 from ..preprocessing import PoniardPreprocessor
 from ..utils.estimate import element_to_list_maybe, get_target_info
-from ..utils.utils import get_kwargs, non_default_repr
+from ..utils.utils import non_default_repr
 from .ensemble import EnsembleMixin
 from .results import ResultsMixin
 from .tuning import TuningMixin
@@ -90,7 +90,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         n_jobs: int | None = None,
     ):
 
-        self._init_params = get_kwargs()
+        self._init_params = {k: v for k, v in locals().items() if k != "self"}
         if metrics and (
             (
                 isinstance(metrics, Sequence)

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -464,8 +464,8 @@ class PoniardPlotFactory:
             labels={"x": "Predicted", "y": "Ground truth", "color": "Count"},
             color_continuous_scale="Blues",
             text_auto=True,
+            template=self._template,
             title="Confusion matrix with cross-validated predictions",
-            **self._px_kwargs(),
         )
         fig.update_yaxes(nticks=len(np.unique(y)) + 1)
         fig.update_xaxes(nticks=len(np.unique(y)) + 1)
@@ -504,9 +504,10 @@ class PoniardPlotFactory:
             estimator, X, features=[feature], kind="average", **kwargs
         )
         response = partial_dep["average"].reshape(-1)
-        n_values = len(partial_dep["values"][0])
+        grid_values = partial_dep.get("grid_values", partial_dep.get("values"))
+        n_values = len(grid_values[0])
         n_repeats = int(len(response) / n_values)
-        values = np.tile(partial_dep["values"][0], n_repeats)
+        values = np.tile(grid_values[0], n_repeats)
         data = pd.DataFrame({"Target": response, f"Feature: {feature}": values})
         hide_legend = False
         if n_repeats > 1 and self._estimator.poniard_task == "classification":
@@ -612,9 +613,30 @@ class PoniardPlotFactory:
         self._apply_layout(fig)
         return fig
 
-    def _full_estimator_analysis(
+    def full_estimator_analysis(
         self, estimator_name: str, height: int = 800, width: int = 800
     ) -> Figure:
+        """Build a 2x2 dashboard for a single estimator.
+
+        Combines the estimator's metric rankings, its performance relative to
+        the nearest better/worse estimators, and its ROC curve / confusion
+        matrix (classification) or residuals (regression), plus permutation
+        importance. This is the most complete single-figure view of one model.
+
+        Parameters
+        ----------
+        estimator_name :
+            Estimator name.
+        height :
+            Figure height. Default 800.
+        width :
+            Figure width. Default 800.
+
+        Returns
+        -------
+        plotly.graph_objects.Figure
+            The dashboard.
+        """
         main_scorer = self._estimator._first_scorer(sklearn_scorer=False)
         sorted_means = self._estimator._long_results.query(
             f"Metric == 'test_{main_scorer}' & Type=='Mean'"

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -29,7 +29,7 @@ except ImportError:
     pl = None
 
 from ..utils.estimate import get_target_info
-from ..utils.utils import get_kwargs, non_default_repr
+from ..utils.utils import non_default_repr
 from .datetime import DatetimeEncoder
 
 if TYPE_CHECKING:
@@ -89,7 +89,7 @@ class PoniardPreprocessor:
         cache_transformations: bool = False,
         cache_dir: str | os.PathLike | None = None,
     ):
-        self._init_params = get_kwargs()
+        self._init_params = {k: v for k, v in locals().items() if k != "self"}
         self.task = task
         self.scaler = scaler or "standard"
         self.high_cardinality_encoder = high_cardinality_encoder or "target"

--- a/poniard/utils/utils.py
+++ b/poniard/utils/utils.py
@@ -1,36 +1,23 @@
 import inspect
 
 
-def get_kwargs(exclude_self: bool = True, back: bool = False):
-    """Returns the kwargs passed to the function/method that calls it."""
-    frame = inspect.currentframe().f_back
-    if back:
-        frame = frame.f_back
-    # co_varnames includes local vars in order; co_argcount limits to params
-    params = frame.f_code.co_varnames[: frame.f_code.co_argcount]
-    local_vars = frame.f_locals
-    kwargs = {}
-    for name in params:
-        if exclude_self and name == "self":
-            continue
-        kwargs[name] = local_vars[name]
-    return kwargs
-
-
 def non_default_repr(obj):
-    """Returns a class repr where only non-default params are included.
+    """Return a class repr showing only non-default constructor params.
 
-    The passed object needs to have the `_init_params` attribute, which
-    is the result of running the `get_kwargs` function within initialization."""
+    The passed object needs the `_init_params` attribute, a dict of the raw
+    kwargs captured at the top of `__init__` (no frame introspection).
+    """
     passed_kwargs = obj._init_params
-    default_params = inspect.signature(obj.__class__).parameters
-    default_params = {name: param.default for name, param in default_params.items()}
-    non_default_params = {name: value for name, value in passed_kwargs.items()
-                          if value != default_params[name]}
+    signature_params = inspect.signature(obj.__class__).parameters
+    non_default_params = {}
+    for name, value in passed_kwargs.items():
+        if name not in signature_params:
+            continue
+        default = signature_params[name].default
+        if default is inspect.Parameter.empty or value != default:
+            non_default_params[name] = value
     params_string = ", ".join(
-        [
-            f"{k}={v}" if not isinstance(v, str) else f"{k}='{v}'"
-            for k, v in non_default_params.items()
-        ]
+        f"{k}={v}" if not isinstance(v, str) else f"{k}='{v}'"
+        for k, v in non_default_params.items()
     )
-    return f"""{obj.__class__.__name__}({params_string})"""
+    return f"{obj.__class__.__name__}({params_string})"

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+from sklearn.linear_model import LinearRegression, LogisticRegression
+
+from poniard import PoniardClassifier, PoniardRegressor
+from poniard.plot import PoniardPlotFactory
+
+
+@pytest.fixture(scope="module")
+def clf_setup():
+    n = 60
+    X = pd.DataFrame(np.random.normal(size=(n, 4)), columns=list("abcd"))
+    y = pd.Series(np.random.choice([0, 1], size=n))
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression()], cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    return X, y, clf
+
+
+@pytest.fixture(scope="module")
+def reg_setup():
+    n = 60
+    X = pd.DataFrame(np.random.normal(size=(n, 4)), columns=list("abcd"))
+    y = pd.Series(np.random.normal(size=n))
+    reg = PoniardRegressor(
+        estimators=[LinearRegression()], cv=2, random_state=0
+    )
+    reg.setup(X, y)
+    reg.fit(X, y)
+    return X, y, reg
+
+
+class TestClassifierPlots:
+    def test_metrics(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).metrics()
+        assert isinstance(fig, go.Figure)
+
+    def test_metrics_bar(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).metrics(kind="bar")
+        assert isinstance(fig, go.Figure)
+
+    def test_overfitness(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).overfitness()
+        assert isinstance(fig, go.Figure)
+
+    def test_permutation_importance(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).permutation_importance(
+            "LogisticRegression", n_repeats=2
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_roc_curve(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).roc_curve()
+        assert isinstance(fig, go.Figure)
+
+    def test_confusion_matrix(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).confusion_matrix("LogisticRegression")
+        assert isinstance(fig, go.Figure)
+
+    def test_partial_dependence(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).partial_dependence(
+            "LogisticRegression", feature=0
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_full_estimator_analysis(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).full_estimator_analysis(
+            "LogisticRegression"
+        )
+        assert isinstance(fig, go.Figure)
+
+
+class TestRegressorPlots:
+    def test_metrics(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).metrics()
+        assert isinstance(fig, go.Figure)
+
+    def test_overfitness(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).overfitness()
+        assert isinstance(fig, go.Figure)
+
+    def test_permutation_importance(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).permutation_importance(
+            "LinearRegression", n_repeats=2
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_partial_dependence(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).partial_dependence(
+            "LinearRegression", feature=0
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_residuals(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).residuals(["LinearRegression"])
+        assert isinstance(fig, go.Figure)
+
+    def test_residuals_histogram(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).residuals_histogram(
+            ["LinearRegression"]
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_full_estimator_analysis(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).full_estimator_analysis(
+            "LinearRegression"
+        )
+        assert isinstance(fig, go.Figure)


### PR DESCRIPTION
## Summary

Roadmap sequencing step 7 — polish the analysis layer: **4.2** (remove frame-introspection repr), **3.3** (discoverability), **3.4** (plotting tests). Item 3.2 was already satisfied by PR #41's explicit-X/y design.

## Changes

### 4.2 — remove `get_kwargs` frame introspection
- Deleted `get_kwargs` (the `inspect.currentframe().f_back` walk in `poniard/utils/utils.py`).
- `PoniardBaseEstimator`, `PoniardPreprocessor` and `ErrorAnalyzer` now capture raw kwargs via a `locals()` one-liner into `_init_params` at the top of `__init__`; `non_default_repr` reads those plus the class signature.
- Repr output is byte-identical to before (required params like `ErrorAnalyzer.task` are still shown).

### 3.3 — discoverability
- `_full_estimator_analysis` → public `full_estimator_analysis` (the 2x2 dashboard). Documented in README; no other code referenced the private name.
- Added `examples/02_error_analysis.ipynb` covering the full error-analysis workflow (rank → merge → target → feature → interpret), verified end-to-end.

### 3.4 — plotting smoke tests
- `tests/test_plotting.py` (15 tests): every `PoniardPlotFactory` method on both classifier and regressor, asserting a `plotly Figure`.
- They immediately caught **two real version bugs** that were previously unexercised:
  - `confusion_matrix` passed `color_discrete_sequence` to `px.imshow` (invalid kwarg → TypeError); now passes only `template`.
  - `partial_dependence` read `partial_dep["values"]`, which sklearn 1.9 renamed to `grid_values` (KeyError); now version-tolerant.

Full suite: 163 passed; `ruff` clean.