### PR TITLE
feat: API diet + tune as experiment glue

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Without `retrain=True`, the returned pipeline is an unfitted clone you can
 inspect. Use it to extract any estimator from the comparison — defaults,
 hyperparameter-optimized ones after `tune_estimator`, or ensemble members.
 
+## Hyperparameter tuning (stays in the experiment)
+
+`tune_estimator` runs a search on the **same** preprocessor/pipeline, then adds
+the winner as a new named estimator (default `{name}_tuned`) so it can be
+cross-validated and compared with everything else — no prep drift, no overwrite.
+
+No default grids: you always pass `grid`. Bare param names are fine; they are
+prefixed with the estimator step automatically:
+
+```python
+clf.tune_estimator("LogisticRegression", X, y, grid={"C": [0.1, 1.0, 10.0]})
+clf.fit(X, y)  # CV the tuned pipeline into the results table
+clf.get_results()
+clf.get_tuning_results("LogisticRegression_tuned")  # best_params_, search, ...
+```
+
+Pipeline-style keys (`LogisticRegression__C`, `preprocessor__...`) still work.
+
 ## Plotting
 
 Plotting is a separate module (requires `pip install poniard[plot]`):

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,292 @@
+# Poniard roadmap
+
+**Thesis:** Poniard is a lightweight scikit-learn companion for *multi-model diagnostics*.
+Compare models to get oriented, then answer *where they fail, whether differences are real,
+and what to try next* — then export a plain sklearn object and leave.
+
+Not AutoML. Not end-to-end. Every feature must earn its place.
+
+**Persona priority**
+
+1. **Primary (B):** where do models fail / what should I fix in the data or features?
+2. **On-ramp (A):** which model family is even viable on this task?
+3. **Exit (C):** what do I export and keep working on outside Poniard?
+
+**Constraints**
+
+- Stay lightweight: core deps remain sklearn/pandas/numpy/scipy/joblib/tqdm; plotly optional.
+- No XGBoost/LightGBM/CatBoost (or similar) as dependencies — user installs and injects.
+- Pure numpy/scipy for stats (no new stats deps).
+- Library is effectively unused → **breaking changes are fine**. Prefer delete over deprecate.
+- Features need a clear "I'd install for this" pull. Commodity wrappers get cut or starved.
+
+**Investment rank**
+
+1. Error analysis (product core)
+2. Prediction similarity → ensemble (closed loop)
+3. Statistical comparison ("is A really better?")
+4. Time/quality surface
+5. Tune-as-experiment-glue (sharpen or cut)
+6. Plotting (support layer for 1–4)
+7. Core compare + preprocessor (maintain, don't expand)
+
+---
+
+## 0. Reposition and shrink surface
+
+**Goal:** Make the wedge obvious in README and API. Kill noise.
+
+### 0.1 README rewrite
+- Lead with diagnostics, not "fit many models."
+- On-ramp: compare → results.
+- Core path: error analysis → similarity/ensemble → export.
+- Plotting mentioned as optional notebook sugar, not a pillar.
+- Drop feature laundry lists that sound like PyCaret-lite.
+
+### 0.2 Public API diet (break freely)
+
+**Done**
+- [x] Delete public `decision_function` (CV path remains via `_predict` for plots)
+- [x] Drop `TargetEncoder` re-export from `poniard.preprocessing`
+- [x] Drop `DateLevel` from package `__all__` (still on `datetime` module for power users)
+- [x] Plots: **left alone** (optional satellite; revisit later)
+- [x] `setup` kept (audit mutator workflow)
+- [x] `tune_estimator` redesigned as experiment glue (see §5 done items)
+
+**Still open**
+- Full README wedge rewrite (with P1 error-analysis story)
+- Plot diet (deferred — owner review)
+- Later headline adds: `compare`, diversity ensemble, pareto
+
+**Ship when:** README tells the new story in one screen; public surface is small enough to hold in your head.
+
+---
+
+## 1. Error analysis as the product
+
+**Goal:** The reason someone installs Poniard. Screenshot-worthy multi-model failure forensics.
+
+### 1.1 Report shape (wow minimum)
+`analyze()` (or a dedicated report object) should make these trivial:
+
+- **Universal failures:** samples every selected model gets wrong (`freq == n_estimators`).
+- **Disagreement set:** samples where models split (useful for ensembling and labeling).
+- **Lift vs baseline:** per target class/bin and per feature value — error rate vs global error rate (not just raw counts).
+- **Top slices:** feature values / bins where error lift ≥ threshold (e.g. 2×), ranked.
+- **Per-estimator summary:** n_errors, error_rate, mean confidence-of-wrong / residual — already mostly there.
+- **Stable indices:** sample ids that survive CV prediction alignment (document assumptions hard).
+
+### 1.2 API cleanup
+- First-class report type (dataclass / simple namespace) instead of a loose dict — still easy to print and index.
+- `from_poniard` default: analyze all non-dummy fitted estimators if names omitted.
+- Avoid recompute traps: reuse cached `cross_val_predict` / proba from the Poniard session when present.
+- Clear separation: ranking definition (classif vs reg) stays explicit and documented.
+
+### 1.3 Stretch (after minimum wow)
+- Simple cohort labels ("high cardinality category X", "target bin top decile").
+- Optional short text summary for notebooks (`report.narrative()` — careful, no LLM deps; templated stats only).
+- Hook points for plots: error lift bars, universal-failure table, disagreement heatmap.
+
+**Ship when:** A user can run `ErrorAnalyzer.from_poniard(clf).analyze(X, y)` and immediately answer:
+"what rows are toxic to every model?", "which slices are 3× worse?", "where do models disagree?"
+
+**Non-goals:** full causal inference, SHAP stack, AutoML root-cause novels.
+
+---
+
+## 2. Diversity → ensemble closed loop
+
+**Goal:** Similarity stops being a trivia method and starts driving decisions.
+
+### 2.1 `build_ensemble` default becomes diversity-aware
+When results + predictions exist:
+
+1. Rank by primary metric (exclude dummies).
+2. Greedily pick members that stay strong **and** low pairwise similarity on errors (or predictions).
+3. Fall back to pure `top_n` if similarity can't be computed.
+
+API sketch:
+
+```python
+clf.build_ensemble(
+    method="stacking",  # or "voting"
+    strategy="diversity",  # default; also "top_n"
+    top_n=3,
+    # optional knobs: min_metric, similarity_threshold, sort_by
+)
+```
+
+### 2.2 Wire the data
+- `get_predictions_similarity` remains public and is what ensemble uses under the hood.
+- Cache CV predictions used for similarity so ensemble doesn't silently recompute forever.
+- Document: similarity `on_errors=True` default and when to flip it.
+
+### 2.3 After ensemble
+- Ensemble is just another named pipeline → `fit` adds it to the comparison table (already true).
+- Error analysis can include the ensemble and show whether universal failures shrank.
+
+**Ship when:** Default ensemble picks a different (and defensible) set than naive top-3 on a dataset where two trees fail alike and a linear model fails differently.
+
+---
+
+## 3. Statistical comparison
+
+**Goal:** Stop pretending fold-mean leaderboards are truth.
+
+### 3.1 Paired fold comparison (pure numpy/scipy)
+- Operate on per-fold scores already in `_experiment_results`.
+- Pairwise tests appropriate for CV folds (document limitations honestly — folds aren't independent).
+- Practical outputs people use:
+  - mean diff + CI
+  - win/tie/loss across folds
+  - simple ranking that resists noise (e.g. mean rank, or CD-diagram data)
+
+### 3.2 API sketch
+
+```python
+clf.compare()                    # all models, primary metric
+clf.compare(metrics=["f1", "roc_auc"])
+clf.compare(estimators=["LogisticRegression", "RandomForestClassifier"])
+```
+
+Returns a small results object / DataFrames: pairwise table + optional ranking summary.
+
+### 3.3 Honesty in docs
+- State clearly: this is **exploratory comparison**, not a paper-grade multiple-testing shrine.
+- Prefer methods implementable without new deps (paired t on fold scores, Wilcoxon, bootstrap CI — pick one solid default + escape hatches).
+
+**Ship when:** User can answer "is RF actually better than LR on this CV, or are we reading noise?" without leaving Poniard.
+
+**Non-goals:** full bayesian hierarchical CV models, author-grade critical difference plot dependency stacks (plot later if easy in plotly).
+
+---
+
+## 4. Time / quality surface
+
+**Goal:** Practical model choice, not only peak metric.
+
+### 4.1 Productize what you already measure
+- `fit_time` / `score_time` already exist in results.
+- Add a first-class view: metric vs log(fit_time) table or Pareto filter.
+- Helpers like "best under T seconds (mean fit_time)" and "within r% of best metric, pick fastest."
+
+### 4.2 API sketch
+
+```python
+clf.get_results()                  # stays
+clf.pareto(metric=None)            # metric vs time, non-dominated
+clf.best_under(seconds=2.0)        # name or row
+```
+
+### 4.3 Plot support (optional)
+- Single scatter: time vs metric, dummy annotated — only if cheap.
+
+**Ship when:** Choosing "good enough and cheap" is one call, not manual dataframe wrangling.
+
+---
+
+## 5. Tune-as-experiment-glue
+
+**Goal:** Better than `get_estimator` → tune outside → `add_estimators` because the
+tuned model re-enters the same experiment with zero prep/CV drift.
+
+### 5.1 Done
+- [x] No default grids
+- [x] Bare param names auto-prefixed (`{"C": [...]}` → `{name}__C`); keys with `__` untouched
+- [x] Side-by-side re-entry default `{name}_tuned`; refuse silent overwrite; custom name OK
+- [x] Unknown baseline / empty grid / bad mode → clear errors
+- [x] `get_tuning_results(name?)` → `best_params_`, `best_score_`, resolved `grid`, fitted `search`
+- [x] README documents the experiment-loop story
+
+### 5.2 Still open
+- [ ] Paired baseline-vs-tuned fold delta once `compare()` (§3) exists
+- [ ] Optionally surface tune summary in `get_results` metadata (low priority)
+
+**Ship when:** §3 can answer “did tuning actually help on these folds?”
+
+---
+
+## 6. Plotting (optional satellite)
+
+**Goal:** Notebook sugar that serves the wedge. Not a product pillar.
+
+### 6.1 Keep / add
+- Metrics overview (on-ramp)
+- Overfitness
+- Confusion / ROC / residuals (task-appropriate basics)
+- **New, high value:** error lift bars, disagreement / similarity heatmap, time-vs-quality scatter
+- `full_estimator_analysis` only if it stays thin and routes through the same data as reports
+
+### 6.2 Cut or bury
+- Partial dependence unless tied to error slices
+- Anything that duplicates sklearn/plotly one-liners without diagnostic context
+
+### 6.3 Messaging
+README: "optional visual analysis" — one short section, not a hero feature.
+
+**Ship when:** plots mostly visualize §1–4 outputs; no orphan chart APIs.
+
+---
+
+## 7. Core compare + preprocessor (maintenance mode)
+
+**Goal:** Reliable on-ramp. No feature sprawl.
+
+### 7.1 Keep sharp
+- Type inference + `reassign_types`
+- Default prep that is boring and correct
+- Dummy baseline always present
+- Clean `get_estimator` exit (no poniard references)
+- Fitted tracking, save/load, side-effect discipline (already invested — don't regress)
+
+### 7.2 UX nits worth breaking for
+- Prefer one obvious happy path (`fit` configures if needed; `setup` remains for mutators between configure and fit, or collapse if setup is pure friction).
+- Naming rules stay boring and documented.
+
+### 7.3 Explicit non-goals
+- Batteries-included GBDT stacks
+- Default search spaces
+- Deep AutoML / pipeline search
+- Target leakage "magic" feature engineering
+
+---
+
+## Suggested delivery order
+
+Break into small releases; each should be install-worthy alone.
+
+| Phase | Theme | Releases as |
+|---|---|---|
+| **P0** | Reposition + API diet + README | breaking cleanup |
+| **P1** | Error analysis report wow (universal fails, lift, disagreement) | headline feature |
+| **P2** | Diversity-default ensemble + prediction cache | closed loop |
+| **P3** | Statistical `compare()` | trust layer |
+| **P4** | Pareto / best_under time-quality | practical choice |
+| **P5** | Tune glue redesign **or** deletion | resolve ambivalence |
+| **P6** | Plot pass aligned to P1–P4 | optional polish |
+
+Parallelism: P0 first. P1 can start immediately after. P2 depends on similarity + cached preds (partially exists). P3 reads fold scores (exists). P4 is small and can slip between larger phases. P5 last among core so compare/error can support tuned deltas. P6 continuously skims off P1–P4.
+
+---
+
+## Definition of done (project-level)
+
+Poniard is "done enough" for this arc when a new user can:
+
+1. Fit a handful of models and see a sane leaderboard with dummy baseline.
+2. Run error analysis and point to toxic rows + high-lift slices + disagreements.
+3. Build a diversity-aware ensemble and see it appear in the same table.
+4. Ask whether model A beats B beyond fold noise.
+5. Pick a fast-enough model, export a pure sklearn pipeline, uninstall Poniard mentally.
+
+If a proposed feature doesn't make one of those five sharper, it doesn't ship.
+
+---
+
+## Open implementation notes (resolve during P0/P1)
+
+- Report type: dataclass vs thin class with `__repr__` tables.
+- Default similarity metric for ensemble selection (error agreement vs prediction association).
+- Which CV-aware statistical default (pick one; document caveats).
+- Whether `setup` remains public or becomes an advanced escape hatch.
+- How aggressively to cache `cross_val_predict` outputs (memory vs UX).

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -576,30 +576,6 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         """
         return self._predict(method="predict_proba", X=X, y=y, estimator_names=estimator_names)
 
-    def decision_function(
-        self, X, y, estimator_names: Sequence[str] | None = None
-    ) -> dict[str, np.ndarray]:
-        """Get cross validated decision function predictions where each sample belongs to a
-        single test set.
-
-        Parameters
-        ----------
-        X :
-            Features.
-        y :
-            Target.
-        estimator_names :
-            Estimators to include. If None, predict all estimators.
-
-        Returns
-        -------
-        dict
-            Dict where keys are estimator names and values are numpy arrays of decision functions.
-        """
-        return self._predict(
-            method="decision_function", X=X, y=y, estimator_names=estimator_names
-        )
-
     def reassign_types(
         self,
         numeric: list[str | int] | None = None,

--- a/poniard/estimators/tuning.py
+++ b/poniard/estimators/tuning.py
@@ -22,28 +22,36 @@ class TuningMixin:
         tuned_estimator_name: str | None = None,
         **kwargs,
     ):
-        """Hyperparameter tuning for a single estimator.
+        """Hyperparameter tuning for a single estimator, reinserted into the experiment.
 
-        Poniard ships no default hyperparameter grids: `grid` must be supplied
-        explicitly. The grid is passed through to the search class, so keys must
-        follow sklearn's pipeline convention and be prefixed with the estimator
-        name (e.g. ``{"LogisticRegression__C": [...]}``).
+        Runs a search on the full pipeline (same preprocessor, same step names), then
+        adds the best estimator as a **new** named pipeline so it can be cross-validated
+        and compared with everything else — no silent overwrite, no prep drift.
+
+        Poniard ships no default hyperparameter grids: ``grid`` is required.
+
+        Grid keys may be bare parameter names (``{"C": [...]}``) or full pipeline
+        keys (``{"LogisticRegression__C": [...]}``). Bare names are prefixed with
+        ``{estimator_name}__`` automatically. Keys that already contain ``__`` are
+        left unchanged (so preprocessor params like ``preprocessor__...`` work).
+
+        After tuning, inspect the search with `get_tuning_results` and compare the
+        new pipeline via `fit` + `get_results` like any other estimator.
 
         Parameters
         ----------
         estimator_name :
-            Estimator to tune.
+            Estimator to tune (must already exist in `pipelines`).
         X :
             Features.
         y :
             Target.
         grid :
-            Hyperparameter grid. Required. Keys must be prefixed with the
-            estimator name (``<estimator_name>__<param>``).
+            Hyperparameter grid. Required.
         mode :
             Type of search. Either "grid", "halving" or "random". Default "grid".
         tuned_estimator_name :
-            Estimator name when adding to `pipelines`. Default None.
+            Name for the tuned pipeline. Default ``{estimator_name}_tuned``.
         kwargs :
             Passed to the search class constructor.
 
@@ -52,51 +60,121 @@ class TuningMixin:
         PoniardBaseEstimator
             Self.
         """
-        estimator = clone(self.pipelines[estimator_name])
+        if estimator_name not in self.pipelines:
+            raise KeyError(
+                f"Unknown estimator {estimator_name!r}. "
+                f"Available: {list(self.pipelines)}"
+            )
         if not grid:
             raise ValueError(
                 "`grid` must be provided: poniard ships no default hyperparameter grids."
             )
+        if mode not in ("grid", "halving", "random"):
+            raise ValueError('mode must be "grid", "halving", or "random".')
+
+        resolved_grid = self._resolve_tuning_grid(estimator_name, grid)
+        estimator = clone(self.pipelines[estimator_name])
         self._pass_instance_attrs(estimator)
 
         scoring = self._first_scorer(sklearn_scorer=True)
+        search_cls = {
+            "grid": GridSearchCV,
+            "halving": HalvingGridSearchCV,
+            "random": RandomizedSearchCV,
+        }[mode]
+        search_kwargs = {
+            "estimator": estimator,
+            "scoring": scoring,
+            "cv": self.cv,
+            "verbose": self.verbose,
+            "n_jobs": self.n_jobs,
+            **kwargs,
+        }
         if mode == "random":
-            search = RandomizedSearchCV(
-                estimator,
-                grid,
-                scoring=scoring,
-                cv=self.cv,
-                verbose=self.verbose,
-                n_jobs=self.n_jobs,
+            search = search_cls(
+                param_distributions=resolved_grid,
                 random_state=self.random_state,
-                **kwargs,
+                **search_kwargs,
             )
         elif mode == "halving":
-            search = HalvingGridSearchCV(
-                estimator,
-                grid,
-                scoring=scoring,
-                cv=self.cv,
-                verbose=self.verbose,
-                n_jobs=self.n_jobs,
+            search = search_cls(
+                param_grid=resolved_grid,
                 random_state=self.random_state,
-                **kwargs,
+                **search_kwargs,
             )
         else:
-            search = GridSearchCV(
-                estimator,
-                grid,
-                scoring=scoring,
-                cv=self.cv,
-                verbose=self.verbose,
-                n_jobs=self.n_jobs,
-                **kwargs,
-            )
+            search = search_cls(param_grid=resolved_grid, **search_kwargs)
+
         search.fit(X, y)
+
         tuned_estimator_name = tuned_estimator_name or f"{estimator_name}_tuned"
-        self.add_estimators(
-            estimators={
-                tuned_estimator_name: clone(search.best_estimator_._final_estimator)
-            }
-        )
+        if tuned_estimator_name in self.pipelines:
+            raise ValueError(
+                f"Pipeline name {tuned_estimator_name!r} already exists. "
+                "Pass tuned_estimator_name=... to choose another name."
+            )
+
+        best_final = clone(search.best_estimator_._final_estimator)
+        self.add_estimators(estimators={tuned_estimator_name: best_final})
+
+        if not hasattr(self, "_tuning_results"):
+            self._tuning_results = {}
+        self._tuning_results[tuned_estimator_name] = {
+            "baseline": estimator_name,
+            "mode": mode,
+            "grid": resolved_grid,
+            "best_params_": dict(search.best_params_),
+            "best_score_": float(search.best_score_),
+            "scorer": scoring,
+            "search": search,
+        }
         return self
+
+    @staticmethod
+    def _resolve_tuning_grid(estimator_name: str, grid: dict) -> dict:
+        """Prefix bare param names with the pipeline step name.
+
+        Keys that already contain ``__`` are treated as full pipeline paths and
+        left unchanged.
+        """
+        resolved = {}
+        prefix = f"{estimator_name}__"
+        for key, values in grid.items():
+            if "__" in key:
+                resolved[key] = values
+            else:
+                resolved[f"{prefix}{key}"] = values
+        return resolved
+
+    def get_tuning_results(self, estimator_name: str | None = None) -> dict:
+        """Return stored hyperparameter search results from `tune_estimator`.
+
+        Parameters
+        ----------
+        estimator_name :
+            Tuned pipeline name (e.g. ``"LogisticRegression_tuned"``). If None
+            and exactly one tune has been run, that result is returned. If None
+            and several exist, a dict keyed by tuned name is returned.
+
+        Returns
+        -------
+        dict
+            Per tune: ``baseline``, ``mode``, ``grid``, ``best_params_``,
+            ``best_score_``, ``scorer``, and the fitted sklearn ``search``
+            object (full escape hatch: ``cv_results_``, etc.).
+        """
+        results = getattr(self, "_tuning_results", None)
+        if not results:
+            raise ValueError(
+                "No tuning results. Call tune_estimator(...) first."
+            )
+        if estimator_name is not None:
+            if estimator_name not in results:
+                raise KeyError(
+                    f"No tuning results for {estimator_name!r}. "
+                    f"Available: {list(results)}"
+                )
+            return results[estimator_name]
+        if len(results) == 1:
+            return next(iter(results.values()))
+        return dict(results)

--- a/poniard/preprocessing/__init__.py
+++ b/poniard/preprocessing/__init__.py
@@ -1,6 +1,4 @@
-from sklearn.preprocessing import TargetEncoder
-
 from poniard.preprocessing.core import PoniardPreprocessor
-from poniard.preprocessing.datetime import DateLevel, DatetimeEncoder
+from poniard.preprocessing.datetime import DatetimeEncoder
 
-__all__ = ["PoniardPreprocessor", "DatetimeEncoder", "DateLevel", "TargetEncoder"]
+__all__ = ["PoniardPreprocessor", "DatetimeEncoder"]

--- a/poniard/preprocessing/datetime.py
+++ b/poniard/preprocessing/datetime.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import validate_data
 
-__all__ = ['DateLevel', 'DatetimeEncoder']
+__all__ = ['DatetimeEncoder']
 
 
 class DateLevel(Enum):

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -86,7 +86,7 @@ def test_save_load_after_tuning(tmp_path):
         "LogisticRegression",
         X,
         y,
-        grid={"LogisticRegression__C": [0.1, 1.0]},
+        grid={"C": [0.1, 1.0]},
     )
     clf.fit(X, y)
     path = tmp_path / "tuned.joblib"

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -2,8 +2,15 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
 
 from poniard import PoniardClassifier
+
+
+def _xy():
+    y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1])
+    x = pd.DataFrame(np.random.normal(size=(len(y), 5)))
+    return x, y
 
 
 @pytest.mark.parametrize(
@@ -15,11 +22,10 @@ from poniard import PoniardClassifier
     ],
 )
 def test_tune(grid, mode):
-    y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1])
-    x = pd.DataFrame(np.random.normal(size=(len(y), 5)))
+    x, y = _xy()
     clf = PoniardClassifier(
         estimators=[LogisticRegression()],
-        random_state=True,
+        random_state=0,
     )
     clf.setup(x, y)
     clf.fit(x, y)
@@ -27,15 +33,96 @@ def test_tune(grid, mode):
     clf.fit(x, y)
     assert clf.get_results().shape[0] == 3
     assert clf.get_results().isna().sum().sum() == 0
+    assert "LogisticRegression_tuned" in clf.pipelines
+
+
+def test_tune_bare_param_names_are_prefixed():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    clf.tune_estimator("LogisticRegression", x, y, grid={"C": [0.1, 1.0]})
+    results = clf.get_tuning_results("LogisticRegression_tuned")
+    assert "LogisticRegression__C" in results["grid"]
+    assert "C" not in results["grid"]
+    assert any(k.endswith("__C") or k == "LogisticRegression__C" for k in results["best_params_"])
+
+
+def test_tune_mixed_grid_keys():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    clf.tune_estimator(
+        "LogisticRegression",
+        x,
+        y,
+        grid={"C": [0.5, 1.0], "LogisticRegression__max_iter": [100, 200]},
+    )
+    grid = clf.get_tuning_results("LogisticRegression_tuned")["grid"]
+    assert grid == {
+        "LogisticRegression__C": [0.5, 1.0],
+        "LogisticRegression__max_iter": [100, 200],
+    }
 
 
 def test_tune_grid_required():
-    y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1])
-    x = pd.DataFrame(np.random.normal(size=(len(y), 5)))
-    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=True)
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
     clf.setup(x, y)
     clf.fit(x, y)
     with pytest.raises(ValueError, match="grid"):
         clf.tune_estimator("LogisticRegression", x, y)
     with pytest.raises(ValueError, match="grid"):
         clf.tune_estimator("LogisticRegression", x, y, grid={})
+
+
+def test_tune_unknown_estimator():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    with pytest.raises(KeyError, match="Unknown estimator"):
+        clf.tune_estimator("Nope", x, y, grid={"C": [1.0]})
+
+
+def test_tune_rejects_name_collision():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    clf.tune_estimator("LogisticRegression", x, y, grid={"C": [0.1, 1.0]})
+    with pytest.raises(ValueError, match="already exists"):
+        clf.tune_estimator("LogisticRegression", x, y, grid={"C": [0.2, 2.0]})
+
+
+def test_tune_custom_name_and_get_results():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    clf.tune_estimator(
+        "LogisticRegression",
+        x,
+        y,
+        grid={"C": [0.1, 1.0]},
+        tuned_estimator_name="lr_search",
+    )
+    out = clf.get_tuning_results("lr_search")
+    assert out["baseline"] == "LogisticRegression"
+    assert out["mode"] == "grid"
+    assert isinstance(out["best_params_"], dict)
+    assert isinstance(out["best_score_"], float)
+    assert isinstance(out["search"], GridSearchCV)
+    assert "lr_search" in clf.pipelines
+    # single tune → bare dict without name key
+    assert clf.get_tuning_results()["baseline"] == "LogisticRegression"
+
+
+def test_get_tuning_results_requires_tune():
+    x, y = _xy()
+    clf = PoniardClassifier(estimators=[LogisticRegression()], random_state=0)
+    clf.setup(x, y)
+    clf.fit(x, y)
+    with pytest.raises(ValueError, match="No tuning results"):
+        clf.get_tuning_results()

--- a/uv.lock
+++ b/uv.lock
@@ -354,7 +354,7 @@ wheels = [
 
 [[package]]
 name = "poniard"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "joblib" },
@@ -381,6 +381,9 @@ plot = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "poniard", extra = ["plot"] },
+    { name = "pre-commit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -401,7 +404,12 @@ requires-dist = [
 provides-extras = ["plot", "dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.16.0" }]
+dev = [
+    { name = "poniard", extras = ["plot"] },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff", specifier = ">=0.16.0" },
+]
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
## Summary
- Remove public `decision_function`; drop `TargetEncoder` / `DateLevel` from `poniard.preprocessing` exports
- Redesign `tune_estimator`: bare param auto-prefix, side-by-side `{name}_tuned` (no overwrite), `get_tuning_results()` escape hatch
- Add diagnostics-first `ROADMAP.md` and document the tune workflow in the README
- Plots left untouched (optional satellite)

## Test plan
- [x] `uv run pytest` — 168 passed
- [x] New tune tests: bare params, mixed keys, collisions, `get_tuning_results`
- [ ] Smoke: `tune_estimator(..., grid={"C": [...]})` → `fit` → `get_results` includes `*_tuned`