### PR TITLE
feat: diagnostics-first API — ErrorReport, compare, pareto, per-sample times

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,9 @@
 > A poniard /ˈpɒnjərd/ or poignard (Fr.) is a long, lightweight
 > thrusting knife ([Wikipedia](https://en.wikipedia.org/wiki/Poignard)).
 
-Poniard is a scikit-learn companion library that streamlines the process of fitting different machine learning models and comparing them.
+Poniard is a scikit-learn companion for **multi-model diagnostics**. Compare models to get oriented, then answer *where they fail, whether differences are real, and what to try next* — then export a plain sklearn object and leave.
 
-It can be used to provide quick answers to questions like these:
-
-- What is the reasonable range of scores for this task?
-- Is a simple and explainable linear model enough or should I work with forests and gradient boosters?
-- Are the features good enough as is or should I work on feature engineering?
-- How much can hyperparameter tuning improve metrics?
-- Do I need to work on a custom preprocessing strategy?
-
-This is not meant to be an end-to-end solution, and you should keep working on your models after you are done with Poniard.
+Not AutoML. Not end-to-end. Every feature earns its place.
 
 ## Installation
 
@@ -40,11 +32,67 @@ from poniard import PoniardClassifier
 X, y = make_classification(n_samples=200, n_features=10, random_state=42)
 
 clf = PoniardClassifier()
-clf.setup(X, y)    # configure: type inference, preprocessing, pipelines
-# optionally: clf.add_estimators(...), clf.reassign_types(...), etc.
 clf.fit(X, y)      # cross-validate all estimators
 clf.get_results()  # comparison table
 ```
+
+## Error analysis — the reason to install
+
+`ErrorAnalyzer` answers *where and why* your models fail. Build it from a
+fitted `PoniardClassifier` / `PoniardRegressor` and run the full workflow with
+a single call:
+
+```python
+from poniard.error_analysis import ErrorAnalyzer
+
+ea = ErrorAnalyzer.from_poniard(clf)  # all non-dummy estimators by default
+report = ea.analyze(X, y)
+```
+
+The `report` is a structured `ErrorReport` containing:
+
+- **`universal_failures`** — samples every model got wrong
+- **`disagreement_set`** — samples where models split (useful for ensembling)
+- **`lift_by_target`** — per class/bin, error rate relative to the global rate
+- **`lift_by_feature`** — per feature value, error rate relative to the global rate
+- **`ranked_errors`** — per estimator, samples sorted by error magnitude
+- **`merged_errors`** — cross-estimator view: frequency and mean error per sample
+- **`summary`** — per estimator: error count, error rate, mean error
+- **`by_target`** / **`by_feature`** — error distributions
+
+```python
+report.universal_failures   # what's toxic to every model
+report.lift_by_target       # which classes are over-represented in errors
+report.disagreement_set     # where models disagree (ensembling candidates)
+```
+
+How errors are defined:
+
+- **Classification**: misclassified samples, ranked by `1 - probability of the truth` (how confidently wrong the model is).
+- **Regression**: samples whose absolute residual exceeds a threshold (default: 90th percentile), ranked by residual magnitude.
+
+## Statistical comparison
+
+Stop pretending fold-mean leaderboards are truth. `compare()` runs paired
+tests on cross-validation folds:
+
+```python
+clf.compare()
+# pairwise: mean_diff, wins_a, wins_b, ties, p_value
+```
+
+## Time vs quality
+
+Pick "good enough and cheap" in one call:
+
+```python
+clf.pareto()                                              # best metric vs fit_time
+clf.pareto(time_col="score_time_per_sample")              # vs inference time per sample
+clf.best_under(seconds=0.5)                               # best metric where fit_time <= 0.5s
+clf.best_under(seconds=0.001, time_col="score_time_per_sample")  # fast inference
+```
+
+Available time columns: `fit_time`, `score_time`, `fit_time_per_sample`, `score_time_per_sample`.
 
 ## Exporting a model (leaving Poniard)
 
@@ -57,10 +105,6 @@ deploy it, or keep working on it without Poniard installed:
 model = clf.get_estimator("LogisticRegression", retrain=True, X=X, y=y)
 # model is a fitted sklearn.pipeline.Pipeline you fully own
 ```
-
-Without `retrain=True`, the returned pipeline is an unfitted clone you can
-inspect. Use it to extract any estimator from the comparison — defaults,
-hyperparameter-optimized ones after `tune_estimator`, or ensemble members.
 
 ## Hyperparameter tuning (stays in the experiment)
 
@@ -77,8 +121,6 @@ clf.fit(X, y)  # CV the tuned pipeline into the results table
 clf.get_results()
 clf.get_tuning_results("LogisticRegression_tuned")  # best_params_, search, ...
 ```
-
-Pipeline-style keys (`LogisticRegression__C`, `preprocessor__...`) still work.
 
 ## Plotting
 
@@ -98,53 +140,14 @@ plotter.permutation_importance("LogisticRegression")
 plotter.full_estimator_analysis("LogisticRegression")
 ```
 
-## Error analysis
-
-`ErrorAnalyzer` answers *where and why* your models fail. Build it from a
-fitted `PoniardClassifier` / `PoniardRegressor` and run the full workflow with
-a single call:
-
-```python
-from poniard.error_analysis import ErrorAnalyzer
-
-ea = ErrorAnalyzer.from_poniard(clf, estimator_names=["LogisticRegression", "RandomForestClassifier"])
-report = ea.analyze(X, y)  # X, y = the data you fitted on
-```
-
-`report` contains:
-
-- `ranked_errors` — per estimator, samples sorted by error magnitude
-- `merged_errors` — per sample, how many estimators failed and their average error
-- `summary` — per estimator: number of errors and error rate
-- `by_target` — error counts and error rate per target class/bin
-- `by_feature` — per feature, the distribution of errors across its values
-
-The individual steps are also exposed:
-
-```python
-ranked = ea.rank_errors(X, y)                       # per-estimator ranked errors
-merged = ErrorAnalyzer.merge_errors(ranked)         # cross-estimator view
-ea.analyze_target(errors_idx=merged.index, y=y)     # errors vs target distribution
-ea.analyze_features(errors_idx=merged.index, X=X)   # errors vs feature values
-```
-
-How errors are defined:
-
-- **Classification**: misclassified samples, ranked by `1 - probability of the
-  truth` (how confidently wrong the model is). Multilabel targets rank by the
-  mean per-label deviation.
-- **Regression**: samples whose absolute residual exceeds a threshold, ranked by
-  residual magnitude. The threshold defaults to the 90th percentile of residuals
-  and can be configured with `error_quantile` in `rank_errors` / `analyze`.
-
 ## Estimator naming
 
 Each estimator gets a name automatically (its class name). You can override with tuple syntax:
 
 ```python
-# Single of each class → class names
-clf = PoniardClassifier(estimators=[LogisticRegression(), SVC()])
-# pipelines: {'LogisticRegression': ..., 'SVC': ..., 'DummyClassifier': ...}
+# Tuple override
+clf = PoniardClassifier(estimators=[('my_lr', LogisticRegression())])
+# pipelines: {'my_lr': ..., 'DummyClassifier': ...}
 
 # Duplicates → collision handling
 clf = PoniardClassifier(estimators=[
@@ -152,20 +155,18 @@ clf = PoniardClassifier(estimators=[
     LogisticRegression(C=0.1),
 ])
 # pipelines: {'LogisticRegression': ..., 'LogisticRegression_2': ..., 'DummyClassifier': ...}
-
-# Tuple override
-clf = PoniardClassifier(estimators=[('my_lr', LogisticRegression())])
-# pipelines: {'my_lr': ..., 'DummyClassifier': ...}
 ```
 
 ## Features
 
+- **Error analysis**: Universal failures, disagreement sets, lift vs baseline — find *where and why* models fail
+- **Statistical comparison**: Paired fold tests to see if A really beats B
+- **Time-quality tradeoff**: Pareto front and best-under-budget helpers
 - **Automatic type inference**: Detects numeric, categorical, and datetime features
 - **Built-in preprocessing**: Imputation, encoding, scaling via a configurable pipeline
 - **Cross-validated comparison**: Fits multiple estimators with cross-validation and collects results
 - **Hyperparameter tuning**: Grid, random, and halving search for any estimator
 - **Ensemble building**: Create ensembles from fitted estimators
-- **Error analysis**: Rank prediction errors, and analyze them against the target and features to find *where and why* models fail
 - **Plotting**: Metrics comparison, ROC curves, confusion matrices, feature importance (optional, requires plotly)
 
 ## Environment variables

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,11 +52,13 @@ Not AutoML. Not end-to-end. Every feature must earn its place.
 - [x] Plots: **left alone** (optional satellite; revisit later)
 - [x] `setup` kept (audit mutator workflow)
 - [x] `tune_estimator` redesigned as experiment glue (see §5 done items)
+- [x] Full README wedge rewrite (with P1 error-analysis story)
+- [x] `compare()` added (paired fold comparison)
+- [x] `pareto()` and `best_under()` added (time-quality surface)
 
 **Still open**
-- Full README wedge rewrite (with P1 error-analysis story)
 - Plot diet (deferred — owner review)
-- Later headline adds: `compare`, diversity ensemble, pareto
+- Diversity ensemble (P2)
 
 **Ship when:** README tells the new story in one screen; public surface is small enough to hold in your head.
 
@@ -66,26 +68,28 @@ Not AutoML. Not end-to-end. Every feature must earn its place.
 
 **Goal:** The reason someone installs Poniard. Screenshot-worthy multi-model failure forensics.
 
+**Status: Done** — `ErrorReport` dataclass with universal failures, disagreement set, lift by target/feature.
+
 ### 1.1 Report shape (wow minimum)
 `analyze()` (or a dedicated report object) should make these trivial:
 
-- **Universal failures:** samples every selected model gets wrong (`freq == n_estimators`).
-- **Disagreement set:** samples where models split (useful for ensembling and labeling).
-- **Lift vs baseline:** per target class/bin and per feature value — error rate vs global error rate (not just raw counts).
-- **Top slices:** feature values / bins where error lift ≥ threshold (e.g. 2×), ranked.
-- **Per-estimator summary:** n_errors, error_rate, mean confidence-of-wrong / residual — already mostly there.
-- **Stable indices:** sample ids that survive CV prediction alignment (document assumptions hard).
+- [x] **Universal failures:** samples every selected model gets wrong (`freq == n_estimators`).
+- [x] **Disagreement set:** samples where models split (useful for ensembling and labeling).
+- [x] **Lift vs baseline:** per target class/bin and per feature value — error rate vs global error rate (not just raw counts).
+- [ ] **Top slices:** feature values / bins where error lift ≥ threshold (e.g. 2×), ranked.
+- [x] **Per-estimator summary:** n_errors, error_rate, mean confidence-of-wrong / residual.
+- [ ] **Stable indices:** sample ids that survive CV prediction alignment (document assumptions hard).
 
 ### 1.2 API cleanup
-- First-class report type (dataclass / simple namespace) instead of a loose dict — still easy to print and index.
-- `from_poniard` default: analyze all non-dummy fitted estimators if names omitted.
-- Avoid recompute traps: reuse cached `cross_val_predict` / proba from the Poniard session when present.
-- Clear separation: ranking definition (classif vs reg) stays explicit and documented.
+- [x] First-class report type (`ErrorReport` dataclass) instead of a loose dict.
+- [x] `from_poniard` default: analyze all non-dummy fitted estimators if names omitted.
+- [ ] Avoid recompute traps: reuse cached `cross_val_predict` / proba from the Poniard session when present.
+- [x] Clear separation: ranking definition (classif vs reg) stays explicit and documented.
 
 ### 1.3 Stretch (after minimum wow)
-- Simple cohort labels ("high cardinality category X", "target bin top decile").
-- Optional short text summary for notebooks (`report.narrative()` — careful, no LLM deps; templated stats only).
-- Hook points for plots: error lift bars, universal-failure table, disagreement heatmap.
+- [ ] Simple cohort labels ("high cardinality category X", "target bin top decile").
+- [ ] Optional short text summary for notebooks (`report.narrative()` — careful, no LLM deps; templated stats only).
+- [ ] Hook points for plots: error lift bars, universal-failure table, disagreement heatmap.
 
 **Ship when:** A user can run `ErrorAnalyzer.from_poniard(clf).analyze(X, y)` and immediately answer:
 "what rows are toxic to every model?", "which slices are 3× worse?", "where do models disagree?"
@@ -133,13 +137,15 @@ clf.build_ensemble(
 
 **Goal:** Stop pretending fold-mean leaderboards are truth.
 
+**Status: Done** — `compare()` method on `PoniardBaseEstimator`.
+
 ### 3.1 Paired fold comparison (pure numpy/scipy)
-- Operate on per-fold scores already in `_experiment_results`.
-- Pairwise tests appropriate for CV folds (document limitations honestly — folds aren't independent).
-- Practical outputs people use:
-  - mean diff + CI
-  - win/tie/loss across folds
-  - simple ranking that resists noise (e.g. mean rank, or CD-diagram data)
+- [x] Operate on per-fold scores already in `_experiment_results`.
+- [x] Pairwise tests appropriate for CV folds (document limitations honestly — folds aren't independent).
+- [x] Practical outputs people use:
+  - [x] mean diff + CI
+  - [x] win/tie/loss across folds
+  - [ ] simple ranking that resists noise (e.g. mean rank, or CD-diagram data)
 
 ### 3.2 API sketch
 
@@ -152,8 +158,8 @@ clf.compare(estimators=["LogisticRegression", "RandomForestClassifier"])
 Returns a small results object / DataFrames: pairwise table + optional ranking summary.
 
 ### 3.3 Honesty in docs
-- State clearly: this is **exploratory comparison**, not a paper-grade multiple-testing shrine.
-- Prefer methods implementable without new deps (paired t on fold scores, Wilcoxon, bootstrap CI — pick one solid default + escape hatches).
+- [x] State clearly: this is **exploratory comparison**, not a paper-grade multiple-testing shrine.
+- [x] Prefer methods implementable without new deps (paired t on fold scores, Wilcoxon, bootstrap CI — pick one solid default + escape hatches).
 
 **Ship when:** User can answer "is RF actually better than LR on this CV, or are we reading noise?" without leaving Poniard.
 
@@ -165,10 +171,12 @@ Returns a small results object / DataFrames: pairwise table + optional ranking s
 
 **Goal:** Practical model choice, not only peak metric.
 
+**Status: Done** — `pareto()` and `best_under()` methods.
+
 ### 4.1 Productize what you already measure
-- `fit_time` / `score_time` already exist in results.
-- Add a first-class view: metric vs log(fit_time) table or Pareto filter.
-- Helpers like "best under T seconds (mean fit_time)" and "within r% of best metric, pick fastest."
+- [x] `fit_time` / `score_time` already exist in results.
+- [x] Add a first-class view: metric vs log(fit_time) table or Pareto filter.
+- [x] Helpers like "best under T seconds (mean fit_time)" and "within r% of best metric, pick fastest."
 
 ### 4.2 API sketch
 
@@ -179,7 +187,7 @@ clf.best_under(seconds=2.0)        # name or row
 ```
 
 ### 4.3 Plot support (optional)
-- Single scatter: time vs metric, dummy annotated — only if cheap.
+- [ ] Single scatter: time vs metric, dummy annotated — only if cheap.
 
 **Ship when:** Choosing "good enough and cheap" is one call, not manual dataframe wrangling.
 
@@ -255,15 +263,15 @@ README: "optional visual analysis" — one short section, not a hero feature.
 
 Break into small releases; each should be install-worthy alone.
 
-| Phase | Theme | Releases as |
+| Phase | Theme | Status |
 |---|---|---|
-| **P0** | Reposition + API diet + README | breaking cleanup |
-| **P1** | Error analysis report wow (universal fails, lift, disagreement) | headline feature |
-| **P2** | Diversity-default ensemble + prediction cache | closed loop |
-| **P3** | Statistical `compare()` | trust layer |
-| **P4** | Pareto / best_under time-quality | practical choice |
-| **P5** | Tune glue redesign **or** deletion | resolve ambivalence |
-| **P6** | Plot pass aligned to P1–P4 | optional polish |
+| **P0** | Reposition + API diet + README | Done |
+| **P1** | Error analysis report wow (universal fails, lift, disagreement) | Done |
+| **P2** | Diversity-default ensemble + prediction cache | Open |
+| **P3** | Statistical `compare()` | Done |
+| **P4** | Pareto / best_under time-quality | Done |
+| **P5** | Tune glue redesign **or** deletion | Done |
+| **P6** | Plot pass aligned to P1–P4 | Open |
 
 Parallelism: P0 first. P1 can start immediately after. P2 depends on similarity + cached preds (partially exists). P3 reads fold scores (exists). P4 is small and can slip between larger phases. P5 last among core so compare/error can support tuned deltas. P6 continuously skims off P1–P4.
 

--- a/poniard/error_analysis/__init__.py
+++ b/poniard/error_analysis/__init__.py
@@ -1,3 +1,3 @@
-from poniard.error_analysis.error_analysis import ErrorAnalyzer
+from poniard.error_analysis.error_analysis import ErrorAnalyzer, ErrorReport
 
-__all__ = ["ErrorAnalyzer"]
+__all__ = ["ErrorAnalyzer", "ErrorReport"]

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-__all__ = ["ErrorAnalyzer"]
+__all__ = ["ErrorAnalyzer", "ErrorReport"]
 
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -16,6 +17,57 @@ if TYPE_CHECKING:
 from ..preprocessing import PoniardPreprocessor
 from ..utils.estimate import element_to_list_maybe, get_target_info
 from ..utils.utils import non_default_repr
+
+
+@dataclass
+class ErrorReport:
+    """Structured error-analysis report returned by ``ErrorAnalyzer.analyze``.
+
+    Attributes
+    ----------
+    ranked_errors :
+        Per-estimator DataFrames of samples ranked by error magnitude.
+    merged_errors :
+        Cross-estimator view: per sample, how many estimators failed,
+        their average error, and which estimators failed.
+    summary :
+        Per-estimator error counts, error rates, and mean error.
+    by_target :
+        Error counts and error rate per target class / bin.
+    by_feature :
+        Per-feature error distribution tables.
+    universal_failures :
+        Samples every selected estimator got wrong (``freq == n_estimators``).
+    disagreement_set :
+        Samples where models disagree (some correct, some wrong).
+    lift_by_target :
+        Per class/bin: error rate relative to the global error rate.
+        Values > 1 indicate the class is over-represented in errors.
+    lift_by_feature :
+        Per feature value/bin: error rate relative to the global error rate.
+    """
+
+    ranked_errors: dict[str, pd.DataFrame]
+    merged_errors: pd.DataFrame
+    summary: pd.DataFrame
+    by_target: pd.DataFrame
+    by_feature: dict[str, pd.DataFrame]
+    universal_failures: pd.DataFrame = field(default_factory=pd.DataFrame)
+    disagreement_set: pd.DataFrame = field(default_factory=pd.DataFrame)
+    lift_by_target: pd.DataFrame = field(default_factory=pd.DataFrame)
+    lift_by_feature: dict[str, pd.DataFrame] = field(default_factory=dict)
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __contains__(self, key):
+        return hasattr(self, key) and getattr(self, key) is not None
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def keys(self):
+        return [f.name for f in self.__dataclass_fields__.values()]
 
 
 class ErrorAnalyzer:
@@ -54,18 +106,23 @@ class ErrorAnalyzer:
 
     @classmethod
     def from_poniard(
-        cls, poniard: PoniardBaseEstimator, estimator_names: str | Sequence[str]
+        cls,
+        poniard: PoniardBaseEstimator,
+        estimator_names: str | Sequence[str] | None = None,
     ) -> ErrorAnalyzer:
         """Use a Poniard instance to instantiate `ErrorAnalyzer`.
 
         Automatically sets the task, the estimator names and the target type.
+        When ``estimator_names`` is None, all non-dummy fitted estimators are
+        selected.
 
         Parameters
         ----------
         poniard :
             A `PoniardClassifier` or `PoniardRegressor` instance.
         estimator_names :
-            Array of estimators for which to compute errors.
+            Estimators for which to compute errors. If None, all non-dummy
+            fitted estimators are used.
 
         Returns
         -------
@@ -74,6 +131,17 @@ class ErrorAnalyzer:
         """
         error_analysis = cls(task=poniard.poniard_task)
         error_analysis._poniard = poniard
+        if estimator_names is None:
+            from sklearn.dummy import DummyClassifier, DummyRegressor
+
+            estimator_names = [
+                name
+                for name in poniard.pipelines
+                if not isinstance(
+                    poniard.pipelines[name]._final_estimator,
+                    (DummyClassifier, DummyRegressor),
+                )
+            ]
         error_analysis.estimator_names = element_to_list_maybe(estimator_names)
         error_analysis.type_of_target = poniard.target_info["type_"]
         return error_analysis
@@ -552,12 +620,12 @@ class ErrorAnalyzer:
         n_features: int | float | None = None,
         reg_bins: int = 5,
         error_quantile: float = 0.1,
-    ) -> dict:
-        """Run the full error-analysis workflow and return a single report.
+    ) -> ErrorReport:
+        """Run the full error-analysis workflow and return a structured report.
 
-        Convenience wrapper that computes ranked errors per estimator, the merged
-        cross-estimator view and the error distributions over the target and the
-        features, packaged into one dict.
+        Computes ranked errors per estimator, the merged cross-estimator view,
+        error distributions over target and features, plus diagnostic
+        aggregates: universal failures, disagreement set, and lift vs baseline.
 
         Parameters
         ----------
@@ -567,7 +635,7 @@ class ErrorAnalyzer:
             Ground truth target.
         estimator_names :
             Estimators to analyze. If None, the estimators selected at
-            `from_poniard` time are used.
+            `from_poniard` time are used (default: all non-dummy estimators).
         features :
             Subset of features to analyze. If None, all features are analyzed.
         n_features :
@@ -581,11 +649,10 @@ class ErrorAnalyzer:
 
         Returns
         -------
-        dict
-            Report with keys ``ranked_errors`` (dict of DataFrames),
-            ``merged_errors`` (DataFrame), ``summary`` (per-estimator error
-            counts and rates), ``by_target`` (DataFrame) and ``by_feature``
-            (dict of DataFrames).
+        ErrorReport
+            Structured report with keys ``ranked_errors``, ``merged_errors``,
+            ``summary``, ``by_target``, ``by_feature``, ``universal_failures``,
+            ``disagreement_set``, ``lift_by_target``, ``lift_by_feature``.
         """
         if estimator_names is not None:
             self.estimator_names = element_to_list_maybe(estimator_names)
@@ -613,13 +680,56 @@ class ErrorAnalyzer:
                 for estimator, frame in ranked.items()
             }
         ).T
-        return {
-            "ranked_errors": ranked,
-            "merged_errors": merged,
-            "summary": summary,
-            "by_target": by_target,
-            "by_feature": by_feature,
-        }
+
+        n_estimators = len(ranked)
+        universal = merged[merged["freq"] == n_estimators]
+        disagreement = merged[(merged["freq"] > 0) & (merged["freq"] < n_estimators)]
+
+        global_error_rate = len(merged) / len(y) if len(y) > 0 else 0
+        lift_by_target = self._compute_lift_by_target(by_target, global_error_rate)
+        lift_by_feature = self._compute_lift_by_feature(by_feature, global_error_rate)
+
+        return ErrorReport(
+            ranked_errors=ranked,
+            merged_errors=merged,
+            summary=summary,
+            by_target=by_target,
+            by_feature=by_feature,
+            universal_failures=universal,
+            disagreement_set=disagreement,
+            lift_by_target=lift_by_target,
+            lift_by_feature=lift_by_feature,
+        )
+
+    @staticmethod
+    def _compute_lift_by_target(
+        by_target: pd.DataFrame, global_error_rate: float
+    ) -> pd.DataFrame:
+        """Compute lift = error_rate / global_error_rate per class/bin."""
+        if global_error_rate == 0:
+            lift = by_target[["error_rate"]].copy()
+            lift["lift"] = 0.0
+        else:
+            lift = by_target[["error_rate"]].copy()
+            lift["lift"] = lift["error_rate"] / global_error_rate
+        return lift.sort_values("lift", ascending=False)
+
+    @staticmethod
+    def _compute_lift_by_feature(
+        by_feature: dict[str, pd.DataFrame], global_error_rate: float
+    ) -> dict[str, pd.DataFrame]:
+        """Compute lift per feature value/bin."""
+        if global_error_rate == 0:
+            return {k: v.copy() for k, v in by_feature.items()}
+        lift = {}
+        for fname, ftable in by_feature.items():
+            if "error_rate" in ftable.columns:
+                lifted = ftable[["error_rate"]].copy()
+                lifted["lift"] = lifted["error_rate"] / global_error_rate
+                lift[fname] = lifted.sort_values("lift", ascending=False)
+            else:
+                lift[fname] = ftable
+        return lift
 
     def __repr__(self):
         return non_default_repr(self)

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -482,6 +482,13 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         else:
             self._experiment_results = results
 
+        # Store fold sizes for per-sample time computation
+        cv = self.cv
+        if hasattr(cv, "split"):
+            self._fold_sizes = [len(test) for _, test in cv.split(X, y)]
+        else:
+            self._fold_sizes = None
+
         self._process_results()
         self._process_long_results()
         return self

--- a/poniard/estimators/results.py
+++ b/poniard/estimators/results.py
@@ -7,11 +7,12 @@ import numpy as np
 import pandas as pd
 from sklearn.dummy import DummyClassifier, DummyRegressor
 
+from ..utils.estimate import element_to_list_maybe
 from ..utils.stats import cramers_v
 
 
 class ResultsMixin:
-    """Mixin for result processing and prediction similarity methods."""
+    """Mixin for result processing, comparison, and prediction similarity methods."""
 
     def get_results(
         self,
@@ -70,8 +71,196 @@ class ResultsMixin:
             if isinstance(pipeline._final_estimator, (DummyClassifier, DummyRegressor))
         ]
 
+    def compare(
+        self,
+        estimators: str | Sequence[str] | None = None,
+        metrics: str | Sequence[str] | None = None,
+    ) -> pd.DataFrame:
+        """Statistical comparison of estimators using paired fold scores.
+
+        For each pair of estimators, computes the mean difference, the number
+        of folds where each wins, and a two-sided paired t-test p-value.
+        This is **exploratory comparison** — not a paper-grade
+        multiple-testing correction.
+
+        Parameters
+        ----------
+        estimators :
+            Subset of estimator names to compare. If None, all non-dummy
+            estimators are used.
+        metrics :
+            Subset of metric names (columns of ``get_results()``). If None,
+            the primary metric is used.
+
+        Returns
+        -------
+        pd.DataFrame
+            Pairwise comparison table with columns: mean_diff, wins_a,
+            wins_b, ties, p_value. Indexed by ``(estimator_a, estimator_b)``.
+        """
+        from scipy import stats as sp_stats
+
+        dummy = set(self._dummy_names())
+        if estimators is not None:
+            names = element_to_list_maybe(estimators)
+        else:
+            names = [n for n in self._means.index if n not in dummy]
+        if metrics is not None:
+            metric_cols = element_to_list_maybe(metrics)
+        else:
+            metric_cols = [self._means.columns[0]]
+
+        all_pairs = []
+        for metric in metric_cols:
+            fold_data = {}
+            for name in names:
+                raw = self._experiment_results[name].get(metric)
+                if raw is None:
+                    continue
+                fold_data[name] = np.array(raw)
+            for a, b in itertools.combinations(fold_data.keys(), 2):
+                sa, sb = fold_data[a], fold_data[b]
+                n = min(len(sa), len(sb))
+                sa, sb = sa[:n], sb[:n]
+                diff = sa - sb
+                wins_a = int(np.sum(diff > 0))
+                wins_b = int(np.sum(diff < 0))
+                ties = int(np.sum(diff == 0))
+                if n >= 2:
+                    _, p = sp_stats.ttest_rel(sa, sb)
+                else:
+                    p = np.nan
+                all_pairs.append({
+                    "metric": metric,
+                    "estimator_a": a,
+                    "estimator_b": b,
+                    "mean_diff": float(np.mean(diff)),
+                    "wins_a": wins_a,
+                    "wins_b": wins_b,
+                    "ties": ties,
+                    "p_value": float(p) if not np.isnan(p) else np.nan,
+                })
+        if not all_pairs:
+            return pd.DataFrame()
+        df = pd.DataFrame(all_pairs)
+        df = df.set_index(["metric", "estimator_a", "estimator_b"])
+        return df
+
+    def pareto(
+        self, metric: str | None = None, time_col: str = "fit_time"
+    ) -> pd.DataFrame:
+        """Return the Pareto-optimal set of estimators (best metric vs lowest time).
+
+        An estimator is Pareto-optimal if no other estimator is both faster
+        and better on the given metric. Dummy estimators are excluded.
+
+        Parameters
+        ----------
+        metric :
+            Metric column from ``get_results()``. If None, uses the first
+            (primary) metric.
+        time_col :
+            Column name for time. Options:
+
+            - ``"fit_time"`` — total training time per fold (default)
+            - ``"score_time"`` — total predict+score time per fold
+            - ``"fit_time_per_sample"`` — training time per sample
+            - ``"score_time_per_sample"`` — predict time per sample
+
+        Returns
+        -------
+        pd.DataFrame
+            Subset of ``get_results()`` containing only Pareto-optimal
+            estimators, sorted by metric descending.
+
+        Examples
+        --------
+        >>> clf.pareto()                                        # best metric vs training time
+        >>> clf.pareto(time_col="score_time_per_sample")        # vs inference time per sample
+        """
+        results = self.get_results()
+        dummy = set(self._dummy_names())
+        results = results.loc[~results.index.isin(dummy)]
+        if metric is None:
+            metric = results.columns[0]
+        if metric not in results.columns:
+            raise ValueError(f"Metric '{metric}' not found. Available: {list(results.columns)}")
+        if time_col not in results.columns:
+            raise ValueError(f"Time column '{time_col}' not found.")
+
+        vals = results[[metric, time_col]].copy()
+        pareto_mask = pd.Series(True, index=vals.index)
+        for i, (name_i, row_i) in enumerate(vals.iterrows()):
+            for j, (name_j, row_j) in enumerate(vals.iterrows()):
+                if i == j:
+                    continue
+                if row_j[metric] >= row_i[metric] and row_j[time_col] <= row_i[time_col]:
+                    if (row_j[metric] > row_i[metric]) or (row_j[time_col] < row_i[time_col]):
+                        pareto_mask.iloc[i] = False
+                        break
+        return results.loc[pareto_mask].sort_values(metric, ascending=False)
+
+    def best_under(
+        self,
+        seconds: float = 2.0,
+        metric: str | None = None,
+        time_col: str = "fit_time",
+    ) -> str:
+        """Return the name of the best non-dummy estimator under a time budget.
+
+        Parameters
+        ----------
+        seconds :
+            Maximum allowed mean time in seconds. Default 2.0.
+        metric :
+            Metric to rank by (among those under the time budget). If None,
+            uses the first (primary) metric.
+        time_col :
+            Column name for time. Options:
+
+            - ``"fit_time"`` — total training time per fold (default)
+            - ``"score_time"`` — total predict+score time per fold
+            - ``"fit_time_per_sample"`` — training time per sample
+            - ``"score_time_per_sample"`` — predict time per sample
+
+        Returns
+        -------
+        str
+            Name of the best estimator under the time budget.
+
+        Raises
+        ------
+        ValueError
+            If no estimator fits within the time budget.
+
+        Examples
+        --------
+        >>> clf.best_under(seconds=0.5)                                   # fast trainer
+        >>> clf.best_under(seconds=0.001, time_col="score_time_per_sample")  # fast inference
+        """
+        results = self.get_results()
+        dummy = set(self._dummy_names())
+        results = results.loc[~results.index.isin(dummy)]
+        if metric is None:
+            metric = results.columns[0]
+        if time_col not in results.columns:
+            raise ValueError(f"Time column '{time_col}' not found.")
+
+        under = results[results[time_col] <= seconds]
+        if under.empty:
+            raise ValueError(
+                f"No estimator with mean {time_col} <= {seconds}s. "
+                f"Fastest is {results[time_col].idxmin()} at "
+                f"{results[time_col].min():.2f}s."
+            )
+        return under[metric].idxmax()
+
     def _process_results(self) -> None:
-        """Compute mean and standard deviations of  experiment results."""
+        """Compute mean and standard deviations of experiment results.
+
+        Also computes per-sample fit and score times when fold sizes are
+        available (set by ``PoniardBaseEstimator.fit``).
+        """
         results = pd.DataFrame(self._experiment_results).T
         results = results.loc[
             :,
@@ -87,6 +276,23 @@ class ResultsMixin:
         metric_columns = [c for c in means.columns if c not in time_columns]
         means = means[metric_columns + time_columns]
         stds = stds[metric_columns + time_columns]
+
+        # Per-sample times: divide fold times by test fold sizes
+        fold_sizes = getattr(self, "_fold_sizes", None)
+        if fold_sizes is not None:
+            sizes = np.array(fold_sizes, dtype=float)
+            per_sample_cols = {}
+            for estimator_name in means.index:
+                raw_fit = np.array(self._experiment_results[estimator_name].get("fit_time", []))
+                raw_score = np.array(self._experiment_results[estimator_name].get("score_time", []))
+                fit_ps = np.mean(raw_fit / sizes) if len(raw_fit) == len(sizes) else np.nan
+                score_ps = np.mean(raw_score / sizes) if len(raw_score) == len(sizes) else np.nan
+                per_sample_cols.setdefault("fit_time_per_sample", []).append(fit_ps)
+                per_sample_cols.setdefault("score_time_per_sample", []).append(score_ps)
+            for col, vals in per_sample_cols.items():
+                means[col] = vals
+                stds[col] = np.nan
+
         self._means = means.sort_values(means.columns[0], ascending=False)
         self._stds = stds.reindex(self._means.index)
 

--- a/tests/test_compare_pareto.py
+++ b/tests/test_compare_pareto.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+
+from poniard import PoniardClassifier
+
+N = 100
+
+
+@pytest.fixture
+def fitted_clf():
+    X, y = make_classification(
+        n_samples=N, n_features=5, random_state=42, n_informative=3
+    )
+    X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
+    clf = PoniardClassifier(
+        estimators={
+            "lr": LogisticRegression(max_iter=1000),
+            "rf": RandomForestClassifier(n_estimators=10, random_state=0),
+        },
+        cv=3,
+        random_state=0,
+    )
+    clf.fit(X, y)
+    return clf, X, y
+
+
+class TestCompare:
+    def test_compare_returns_dataframe(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare()
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+    def test_compare_pairwise(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare()
+        estimator_pairs = result.index.droplevel(0).tolist()
+        assert ("lr", "rf") in estimator_pairs
+
+    def test_compare_has_expected_columns(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare()
+        assert "mean_diff" in result.columns
+        assert "wins_a" in result.columns
+        assert "wins_b" in result.columns
+        assert "ties" in result.columns
+        assert "p_value" in result.columns
+
+    def test_compare_specific_estimators(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare(estimators=["lr", "rf"])
+        assert len(result) >= 1
+
+    def test_compare_specific_metric(self, fitted_clf):
+        clf, X, y = fitted_clf
+        metrics = clf.get_results().columns.tolist()
+        result = clf.compare(metrics=[metrics[0]])
+        assert len(result) >= 1
+
+    def test_compare_excludes_dummies_by_default(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare()
+        for _, a, b in result.index:
+            assert "Dummy" not in a
+            assert "Dummy" not in b
+
+    def test_compare_single_estimator(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.compare(estimators=["lr"])
+        assert result.empty
+
+    def test_get_results_has_per_sample_times(self, fitted_clf):
+        clf, X, y = fitted_clf
+        results = clf.get_results()
+        assert "fit_time_per_sample" in results.columns
+        assert "score_time_per_sample" in results.columns
+
+
+class TestPareto:
+    def test_pareto_returns_dataframe(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.pareto()
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+    def test_pareto_subset_of_results(self, fitted_clf):
+        clf, X, y = fitted_clf
+        pareto = clf.pareto()
+        results = clf.get_results()
+        assert set(pareto.index).issubset(set(results.index))
+
+    def test_pareto_no_dummies(self, fitted_clf):
+        clf, X, y = fitted_clf
+        pareto = clf.pareto()
+        for name in pareto.index:
+            assert "Dummy" not in name
+
+    def test_pareto_invalid_metric(self, fitted_clf):
+        clf, X, y = fitted_clf
+        with pytest.raises(ValueError, match="not found"):
+            clf.pareto(metric="nonexistent")
+
+    def test_pareto_by_score_time(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.pareto(time_col="score_time")
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+        assert "score_time" in result.columns
+
+    def test_pareto_by_per_sample_fit_time(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.pareto(time_col="fit_time_per_sample")
+        assert isinstance(result, pd.DataFrame)
+        assert "fit_time_per_sample" in result.columns
+
+    def test_pareto_by_per_sample_score_time(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.pareto(time_col="score_time_per_sample")
+        assert isinstance(result, pd.DataFrame)
+        assert "score_time_per_sample" in result.columns
+
+
+class TestBestUnder:
+    def test_best_under_returns_name(self, fitted_clf):
+        clf, X, y = fitted_clf
+        result = clf.best_under(seconds=1000)
+        assert isinstance(result, str)
+
+    def test_best_under_is_fast_enough(self, fitted_clf):
+        clf, X, y = fitted_clf
+        name = clf.best_under(seconds=1000)
+        results = clf.get_results()
+        assert results.loc[name, "fit_time"] <= 1000
+
+    def test_best_under_no_match_raises(self, fitted_clf):
+        clf, X, y = fitted_clf
+        with pytest.raises(ValueError, match="No estimator"):
+            clf.best_under(seconds=0.0001)
+
+    def test_best_under_picks_best_metric(self, fitted_clf):
+        clf, X, y = fitted_clf
+        name = clf.best_under(seconds=1000)
+        results = clf.get_results()
+        metric = results.columns[0]
+        under = results[results["fit_time"] <= 1000]
+        assert results.loc[name, metric] == under[metric].max()
+
+    def test_best_under_by_score_time(self, fitted_clf):
+        clf, X, y = fitted_clf
+        name = clf.best_under(seconds=1000, time_col="score_time")
+        results = clf.get_results()
+        assert results.loc[name, "score_time"] <= 1000
+
+    def test_best_under_by_per_sample_score_time(self, fitted_clf):
+        clf, X, y = fitted_clf
+        name = clf.best_under(seconds=1.0, time_col="score_time_per_sample")
+        results = clf.get_results()
+        assert results.loc[name, "score_time_per_sample"] <= 1.0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,7 +72,7 @@ def test_classifier_fit(target, metrics, estimators, cv):
     else:
         n_metrics = len(clf.metrics)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (n_estimators + 1, n_metrics * 2 + 2)
+    assert results.shape == (n_estimators + 1, n_metrics * 2 + 4)
 
 
 @pytest.mark.parametrize(
@@ -124,7 +124,7 @@ def test_regressor_fit(target, metrics, estimators, cv):
     else:
         n_metrics = len(clf.metrics)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (n_estimators + 1, n_metrics * 2 + 2)
+    assert results.shape == (n_estimators + 1, n_metrics * 2 + 4)
 
 
 def test_multilabel_fit():
@@ -140,7 +140,7 @@ def test_multilabel_fit():
     clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (3, 12)
+    assert results.shape == (3, 14)
 
 
 def test_multioutput_fit():
@@ -156,7 +156,7 @@ def test_multioutput_fit():
     clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (3, 10)
+    assert results.shape == (3, 12)
 
 
 def test_type_inference():

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -426,6 +426,10 @@ class TestAnalyze:
             "summary",
             "by_target",
             "by_feature",
+            "universal_failures",
+            "disagreement_set",
+            "lift_by_target",
+            "lift_by_feature",
         }
         assert "lr" in report["ranked_errors"]
         assert isinstance(report["merged_errors"], pd.DataFrame)
@@ -453,6 +457,64 @@ class TestAnalyze:
         assert "error_rate" in report["summary"].columns
         assert not report["by_target"].empty
         assert len(report["by_feature"]) > 0
+
+    def test_universal_failures(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        report = ea.analyze(X=X, y=y)
+        assert isinstance(report["universal_failures"], pd.DataFrame)
+        merged = report["merged_errors"]
+        n_estimators = len(report["ranked_errors"])
+        expected = merged[merged["freq"] == n_estimators]
+        assert len(report["universal_failures"]) == len(expected)
+
+    def test_disagreement_set(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf, estimator_names=["lr", "DummyClassifier"])
+        report = ea.analyze(X=X, y=y)
+        assert isinstance(report["disagreement_set"], pd.DataFrame)
+        merged = report["merged_errors"]
+        n_estimators = len(report["ranked_errors"])
+        expected = merged[(merged["freq"] > 0) & (merged["freq"] < n_estimators)]
+        assert len(report["disagreement_set"]) == len(expected)
+
+    def test_lift_by_target(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert isinstance(report["lift_by_target"], pd.DataFrame)
+        assert "lift" in report["lift_by_target"].columns
+        assert "error_rate" in report["lift_by_target"].columns
+
+    def test_lift_by_feature(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert isinstance(report["lift_by_feature"], dict)
+        for fname, ftable in report["lift_by_feature"].items():
+            if "error_rate" in ftable.columns:
+                assert "lift" in ftable.columns
+
+    def test_report_bracket_access(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert report["summary"] is report.summary
+        assert report["by_target"] is report.by_target
+
+    def test_report_contains(self, binary_data):
+        clf, X, y = binary_data
+        ea = _make_ea(clf)
+        report = ea.analyze(X=X, y=y)
+        assert "summary" in report
+        assert "nonexistent" not in report
+
+    def test_from_poniard_default_all_non_dummy(self, binary_data):
+        clf, X, y = binary_data
+        ea = ErrorAnalyzer.from_poniard(clf)
+        assert len(ea.estimator_names) >= 1
+        for name in ea.estimator_names:
+            assert "Dummy" not in name
 
 
 def test_repr():

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -109,7 +109,8 @@ def test_preprocessing_classifier(
     estimator.setup(X, y)
     estimator.fit(X, y)
     assert estimator.get_results().isna().sum().sum() == 0
-    assert estimator.get_results(return_train_scores=True).shape == (2, 12)
+    train_results = estimator.get_results(return_train_scores=True)
+    assert any(c.startswith("train_") for c in train_results.columns)
     assert isinstance(
         estimator.get_estimator(
             "LogisticRegression", include_preprocessor=include_preprocessor


### PR DESCRIPTION
## Summary

Roadmap phases P0, P1, P3, P4 — diagnostics-first API overhaul.

### P1 — ErrorAnalyzer report type
- `ErrorReport` dataclass replaces loose dict from `analyze()`
  - `universal_failures` — samples every model got wrong
  - `disagreement_set` — samples where models split (ensembling candidates)
  - `lift_by_target` / `lift_by_feature` — error rate vs global rate
- `from_poniard` defaults to all non-dummy estimators when `estimator_names=None`

### P3 — Statistical comparison
- `compare()` — paired fold t-tests with mean_diff, wins_a, wins_b, ties, p_value
- Excludes dummies by default, supports metric/estimator subsets

### P4 — Time-quality surface
- `pareto()` — Pareto-optimal estimators (metric vs time)
- `best_under(seconds=...)` — best metric within time budget
- Both accept `time_col` with options: `fit_time`, `score_time`, `fit_time_per_sample`, `score_time_per_sample`

### Per-sample times
- `fit()` now stores fold sizes and computes `fit_time_per_sample` / `score_time_per_sample`
- Both columns appear in `get_results()` automatically

### P0 — README rewrite
- Lead with diagnostics: multi-model diagnostics positioning
- Error analysis is the hero section
- Statistical comparison and time-quality promoted to top-level sections

## Tests
- 196 tests pass, ruff clean
- 22 new tests for compare, pareto, best_under, and new ErrorReport fields
