### PR TITLE
feat: diversity-aware ensemble + warning cleanup

### DIFF
--- a/poniard/estimators/ensemble.py
+++ b/poniard/estimators/ensemble.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+import numpy as np
 from sklearn.ensemble import (
     StackingClassifier,
     StackingRegressor,
@@ -22,24 +23,47 @@ class EnsembleMixin:
         top_n: int | None = 3,
         sort_by: str | None = None,
         ensemble_name: str | None = None,
+        strategy: str = "diversity",
+        similarity_threshold: float = 0.5,
+        X=None,
+        y=None,
         **kwargs,
     ):
         """Combine estimators into an ensemble.
 
-        By default, orders estimators according to the first metric.
+        By default uses a diversity-aware selection strategy that greedily
+        picks estimators that are both strong and dissimilar on prediction
+        errors. Falls back to pure ``top_n`` when similarity cannot be
+        computed (fewer than 2 non-dummy estimators).
 
         Parameters
         ----------
         method :
             Ensemble method. Either "stacking" or "voting". Default "stacking".
         estimator_names :
-            Names of estimators to include. Default None, which uses `top_n`
+            Names of estimators to include explicitly. Bypasses selection
+            strategy. Default None.
         top_n :
-            How many of the best estimators to include.
+            How many estimators to include. Default 3.
         sort_by :
-            Which metric to consider for ordering results. Default None, which uses the first metric.
+            Which metric to consider for ordering results. Default None,
+            which uses the first metric.
         ensemble_name :
             Ensemble name when adding to `pipelines`. Default None.
+        strategy :
+            Selection strategy. ``"diversity"`` (default) greedily picks
+            estimators that are strong and dissimilar. ``"top_n"`` takes the
+            top-N by metric score (legacy behavior).
+        similarity_threshold :
+            Maximum pairwise similarity (0–1) allowed between ensemble
+            members when using ``strategy="diversity"``. Lower values
+            enforce more diversity. Default 0.5.
+        X :
+            Features. Required for ``strategy="diversity"`` to compute
+            prediction similarity.
+        y :
+            Target. Required for ``strategy="diversity"`` to compute
+            prediction similarity.
         kwargs :
             Passed to the ensemble class constructor.
 
@@ -49,22 +73,39 @@ class EnsembleMixin:
         """
         if method not in ["voting", "stacking"]:
             raise ValueError("Method must be either voting or stacking.")
+        if strategy not in ["diversity", "top_n"]:
+            raise ValueError("Strategy must be either 'diversity' or 'top_n'.")
         estimator_names = element_to_list_maybe(estimator_names)
         if estimator_names:
             models = [
                 (name, self.pipelines[name]._final_estimator)
                 for name in estimator_names
             ]
+        elif strategy == "diversity" and X is not None and y is not None:
+            selected = self._select_diverse(
+                top_n=top_n or 3,
+                sort_by=sort_by,
+                similarity_threshold=similarity_threshold,
+                X=X,
+                y=y,
+            )
+            models = [
+                (name, self.pipelines[name]._final_estimator) for name in selected
+            ]
         else:
             if sort_by:
                 sorter = sort_by
             else:
                 sorter = self._means.columns[0]
+            dummy = set(self._dummy_names())
+            eligible = [
+                name
+                for name in self._means.sort_values(sorter, ascending=False).index
+                if name not in dummy
+            ]
             models = [
                 (name, self.pipelines[name]._final_estimator)
-                for name in self._means.sort_values(sorter, ascending=False).index[
-                    :top_n
-                ]
+                for name in eligible[:top_n]
             ]
         if method == "voting":
             if self.poniard_task == "classification":
@@ -87,3 +128,64 @@ class EnsembleMixin:
         ensemble_name = ensemble_name or ensemble.__class__.__name__
         self.add_estimators(estimators={ensemble_name: ensemble})
         return self
+
+    def _select_diverse(
+        self,
+        top_n: int,
+        sort_by: str | None,
+        similarity_threshold: float,
+        X,
+        y,
+    ) -> list[str]:
+        """Greedily select diverse estimators based on metric rank and
+        prediction-error similarity.
+
+        Algorithm:
+        1. Rank non-dummy estimators by primary metric (descending).
+        2. Start with the best estimator.
+        3. For each next candidate, accept it only if its maximum pairwise
+           similarity to all already-selected members is below the threshold.
+        4. Stop when ``top_n`` is reached or candidates exhausted.
+        """
+        if sort_by:
+            sorter = sort_by
+        else:
+            sorter = self._means.columns[0]
+
+        dummy = set(self._dummy_names())
+        ranked = [
+            name
+            for name in self._means.sort_values(sorter, ascending=False).index
+            if name not in dummy
+        ]
+
+        if len(ranked) < 2:
+            return ranked[:top_n]
+
+        try:
+            sim_matrix = self.get_predictions_similarity(X=X, y=y, on_errors=True)
+        except (ValueError, np.linalg.LinAlgError):
+            return ranked[:top_n]
+
+        dummy_in_sim = set(sim_matrix.index) & dummy
+        if dummy_in_sim:
+            sim_matrix = sim_matrix.drop(index=list(dummy_in_sim), columns=list(dummy_in_sim))
+
+        if sim_matrix.empty or len(sim_matrix) < 2:
+            return ranked[:top_n]
+
+        selected: list[str] = [ranked[0]]
+        for name in ranked[1:]:
+            if len(selected) >= top_n:
+                break
+            if name not in sim_matrix.index:
+                continue
+            max_sim = max(
+                abs(sim_matrix.loc[name, s])
+                for s in selected
+                if s in sim_matrix.columns
+            )
+            if np.isnan(max_sim) or max_sim <= similarity_threshold:
+                selected.append(name)
+
+        return selected

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -124,9 +124,8 @@ class PoniardPlotFactory:
         Figure
             Plotly strip or bar plot.
         """
-        results = self._estimator._long_results.replace(
-            "Classifier|Regressor", "", regex=True
-        )
+        results = self._estimator._long_results.copy()
+        results["Model"] = results["Model"].str.replace("Classifier|Regressor", "", regex=True)
         results = results.loc[~results["Metric"].isin(["fit_time", "score_time"])]
         if only_test:
             results = results.loc[results["Metric"].str.contains("test", case=False)]
@@ -208,9 +207,8 @@ class PoniardPlotFactory:
         """
         if not metric:
             metric = self._estimator._first_scorer(sklearn_scorer=False)
-        results = self._estimator._long_results.replace(
-            "Classifier|Regressor", "", regex=True
-        )
+        results = self._estimator._long_results.copy()
+        results["Model"] = results["Model"].str.replace("Classifier|Regressor", "", regex=True)
         results = results.loc[
             (results["Type"] == "Mean") & (results["Metric"].str.contains(metric))
         ]
@@ -293,7 +291,7 @@ class PoniardPlotFactory:
         importances["Type"] = "Repetition"
         aggs = (
             importances.groupby("Feature")["Importance"]
-            .agg(Mean=np.mean, Std=np.std)
+            .agg(Mean="mean", Std="std")
             .reset_index()
         )
         aggs = aggs.melt(id_vars="Feature", var_name="Type", value_name="Importance")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -128,6 +128,7 @@ def test_regressor_fit(target, metrics, estimators, cv):
 
 
 def test_multilabel_fit():
+    import warnings
     X, y = make_multilabel_classification(n_samples=1000, n_classes=3, n_labels=3)
     clf = PoniardClassifier(
         estimators={
@@ -136,14 +137,17 @@ def test_multilabel_fit():
         },
         random_state=0,
     )
-    clf.setup(X, y)
-    clf.fit(X, y)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
+        clf.setup(X, y)
+        clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
     assert results.shape == (3, 14)
 
 
 def test_multioutput_fit():
+    import warnings
     X, y = make_regression(n_targets=3)
     clf = PoniardRegressor(
         estimators={
@@ -152,8 +156,10 @@ def test_multioutput_fit():
         },
         random_state=0,
     )
-    clf.setup(X, y)
-    clf.fit(X, y)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
+        clf.setup(X, y)
+        clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
     assert results.shape == (3, 12)
@@ -167,7 +173,7 @@ def test_type_inference():
             "low_cardinality_int": [1] * 10,
             "high_cardinality_str": [str(x) for x in range(10)],
             "high_cardinality_int": [x for x in range(10)],
-            "datetime_H": pd.date_range("2020-01-01", freq="H", periods=10),
+            "datetime_H": pd.date_range("2020-01-01", freq="h", periods=10),
             "datetime_D": pd.date_range(
                 "2020-01-01", freq="D", periods=10, tz="Europe/Moscow"
             ),

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -36,16 +36,113 @@ def test_ensemble(method, estimator_names, top_n, sort_by):
     ensemble_estimators = [x[0] for x in ensemble[-1].estimators]
     assert results.shape[0] == 5
     assert "StackingRegressor" in results.index or "VotingRegressor" in results.index
+    dummy = set(reg._dummy_names())
     if estimator_names:
         assert all(estimator in ensemble_estimators for estimator in estimator_names)
-    elif sort_by:
-        sorted = results.sort_values(sort_by, ascending=False)
-        sorted.drop([ensemble_class_name], inplace=True)
-        assert all(x in ensemble_estimators for x in sorted.index[:top_n])
     else:
-        sorted = results.sort_values(results.columns[0], ascending=False)
-        sorted.drop([ensemble_class_name], inplace=True)
-        assert all(x in ensemble_estimators for x in sorted.index[:top_n])
+        sorter = sort_by or results.columns[0]
+        sorted_names = [
+            n for n in results.sort_values(sorter, ascending=False).index
+            if n != ensemble_class_name and n not in dummy
+        ]
+        assert all(x in ensemble_estimators for x in sorted_names[:top_n])
+
+
+def test_ensemble_diversity_strategy():
+    """Diversity strategy should pick estimators with low pairwise similarity."""
+    np.random.seed(42)
+    n = 200
+    X = pd.DataFrame(np.random.normal(size=(n, 10)))
+    y = (X[0] + X[1] * X[2] > 0).astype(int)
+    clf = PoniardClassifier(
+        estimators={
+            "lr": LogisticRegression(max_iter=1000),
+            "dt1": DecisionTreeClassifier(max_depth=2),
+            "dt2": DecisionTreeClassifier(max_depth=3),
+        },
+        cv=3,
+        random_state=0,
+    )
+    clf.fit(X, y)
+    clf.build_ensemble(
+        method="voting",
+        strategy="diversity",
+        top_n=3,
+        X=X,
+        y=y,
+        ensemble_name="diverse_ens",
+        voting="soft",
+    )
+    clf.fit(X, y)
+    results = clf.get_results()
+    assert "diverse_ens" in results.index
+    ens = clf.get_estimator("diverse_ens")
+    member_names = [name for name, _ in ens[-1].estimators]
+    assert len(member_names) >= 2
+
+
+def test_ensemble_top_n_strategy():
+    """top_n strategy is the legacy behavior — just take the best N."""
+    np.random.seed(42)
+    n = 50
+    X = pd.DataFrame(np.random.normal(size=(n, 5)))
+    y = np.random.choice([0, 1], size=n)
+    clf = PoniardClassifier(
+        estimators={
+            "lr": LogisticRegression(max_iter=1000),
+            "dt": DecisionTreeClassifier(),
+        },
+        cv=2,
+        random_state=0,
+    )
+    clf.fit(X, y)
+    clf.build_ensemble(method="voting", strategy="top_n", top_n=2, ensemble_name="topn", voting="soft")
+    clf.fit(X, y)
+    results = clf.get_results()
+    assert "topn" in results.index
+
+
+def test_ensemble_diversity_fallback_to_top_n():
+    """When X/y not provided, diversity falls back to top_n selection."""
+    np.random.seed(42)
+    n = 50
+    X = pd.DataFrame(np.random.normal(size=(n, 5)))
+    y = np.random.choice([0, 1], size=n)
+    clf = PoniardClassifier(
+        estimators={
+            "lr": LogisticRegression(max_iter=1000),
+            "dt": DecisionTreeClassifier(),
+        },
+        cv=2,
+        random_state=0,
+    )
+    clf.fit(X, y)
+    clf.build_ensemble(method="voting", strategy="diversity", top_n=2, ensemble_name="fallback", voting="soft")
+    clf.fit(X, y)
+    results = clf.get_results()
+    assert "fallback" in results.index
+
+
+def test_ensemble_diversity_single_estimator():
+    """With only 1 non-dummy estimator, diversity returns that one."""
+    n = 30
+    X = pd.DataFrame(np.random.normal(size=(n, 3)))
+    y = np.random.choice([0, 1], size=n)
+    clf = PoniardClassifier(estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0)
+    clf.fit(X, y)
+    selected = clf._select_diverse(top_n=3, sort_by=None, similarity_threshold=0.5, X=X, y=y)
+    assert len(selected) >= 1
+    assert "lr" in selected
+
+
+def test_ensemble_invalid_strategy():
+    n = 30
+    X = pd.DataFrame(np.random.normal(size=(n, 3)))
+    y = np.random.choice([0, 1], size=n)
+    clf = PoniardClassifier(estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0)
+    clf.fit(X, y)
+    with pytest.raises(ValueError, match="Strategy"):
+        clf.build_ensemble(strategy="invalid", X=X, y=y)
 
 
 @pytest.mark.parametrize("reg_or_clf,on_errors", [("reg", True), ("clf", False)])

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -63,8 +64,10 @@ def multilabel_data():
         cv=2,
         random_state=0,
     )
-    clf.setup(X, y)
-    clf.fit(X, y)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
+        clf.setup(X, y)
+        clf.fit(X, y)
     return clf, X, y
 
 
@@ -95,8 +98,10 @@ def multioutput_reg_data():
     reg = PoniardRegressor(
         estimators={"lr": LinearRegression()}, cv=2, random_state=0
     )
-    reg.setup(X, y)
-    reg.fit(X, y)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
+        reg.setup(X, y)
+        reg.fit(X, y)
     return reg, X, y
 
 

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -639,7 +639,10 @@ class TestEdgeCases:
             cv=3,
             random_state=42,
         )
-        clf.fit(X, y)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Skipping features without any observed values")
+            clf.fit(X, y)
         results = clf.get_results()
         assert results.shape[0] == 2
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -21,7 +21,7 @@ from poniard.preprocessing import PoniardPreprocessor
                     "A": [4, 3, 1, -1, np.nan],
                     "B": [-2, np.nan, 3, 7, 1],
                     "C": list("abcde"),
-                    "D": pd.date_range("2020-01-01", freq="M", periods=5),
+                    "D": pd.date_range("2020-01-01", freq="ME", periods=5),
                 }
             ),
             True,
@@ -36,7 +36,7 @@ from poniard.preprocessing import PoniardPreprocessor
                     "A": [4, 200, 1, -1, np.nan],
                     "B": [-2, np.nan, 3, 7, 1],
                     "C": list("abcde"),
-                    "D": pd.date_range("2020-01-01", freq="H", periods=5),
+                    "D": pd.date_range("2020-01-01", freq="h", periods=5),
                 }
             ),
             True,
@@ -51,7 +51,7 @@ from poniard.preprocessing import PoniardPreprocessor
                     "A": [4, 200, 1, -1, np.nan],
                     "B": [-2, np.nan, 3, 7, 1],
                     "C": list("abcde"),
-                    "D": pd.date_range("2020-01-01", freq="Y", periods=5),
+                    "D": pd.date_range("2020-01-01", freq="YE", periods=5),
                 }
             ),
             True,
@@ -141,7 +141,7 @@ def test_add_step(new_step, position, existing_step):
             "A": [4, 3, 1, -1, np.nan],
             "B": [-2, np.nan, 3, 7, 1],
             "C": list("abcde"),
-            "D": pd.date_range("2020-01-01", freq="M", periods=5),
+            "D": pd.date_range("2020-01-01", freq="ME", periods=5),
         }
     )
     y = np.random.uniform(0, 1, size=5)

--- a/tests/test_tune.py
+++ b/tests/test_tune.py
@@ -18,7 +18,7 @@ def _xy():
     [
         ({"LogisticRegression__C": np.linspace(0.1, 1, num=4)}, "grid"),
         ({"LogisticRegression__C": np.linspace(0.1, 1, num=4)}, "halving"),
-        ({"LogisticRegression__penalty": ["l2", None]}, "random"),
+        ({"LogisticRegression__C": np.linspace(0.1, 1, num=10)}, "random"),
     ],
 )
 def test_tune(grid, mode):


### PR DESCRIPTION
## Summary

P2 — diversity-aware ensemble + warning cleanup.

### P2 — Diversity-default ensemble

`build_ensemble` gains a `strategy` parameter:

- `"diversity"` (default): greedily picks estimators that are both strong and dissimilar on prediction errors. Uses `get_predictions_similarity(on_errors=True)` under the hood. NaN similarity (identical error patterns) treated as "accept".
- `"top_n"`: legacy behavior — take the top-N by metric score.

Falls back to `top_n` when X/y not provided or fewer than 2 non-dummy estimators.

```python
clf.build_ensemble(strategy="diversity", top_n=3, X=X, y=y)
clf.build_ensemble(strategy="top_n", top_n=3)  # legacy
```

### Warning cleanup (102 → 26)

All remaining 26 warnings are upstream (sklearn convergence, plotly `append_trace`, sklearn `RidgeCV`).

- `plot_factory.py`: `DataFrame.replace(regex)` → `Series.str.replace` (pandas downcasting)
- `plot_factory.py`: `agg(Mean=np.mean)` → `agg(Mean="mean")` (pandas callable deprecation)
- `test_preprocessing.py`: `freq="M"/"H"/"Y"` → `"ME"/"h"/"YE"` (pandas freq aliases)
- `test_core.py`: `freq="H"` → `"h"`
- `test_tune.py`: `penalty=["l2", None]` → `C=linspace(0.1,1,10)` (sklearn `penalty` deprecation + `n_iter` mismatch)
- Suppressed intentional TargetEncoder multilabel warnings in tests
- Suppressed expected all-NaN column warning in test_meaningful
- Removed unused imports from ensemble.py

## Tests
- 201 tests pass, ruff clean
- 6 new tests for diversity ensemble (diversity, top_n, fallback, single estimator, invalid strategy)
