### PR TITLE
feat: plot pass aligned to P1–P4 — lift bars, similarity heatmap, time-quality scatter

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -267,11 +267,11 @@ Break into small releases; each should be install-worthy alone.
 |---|---|---|
 | **P0** | Reposition + API diet + README | Done |
 | **P1** | Error analysis report wow (universal fails, lift, disagreement) | Done |
-| **P2** | Diversity-default ensemble + prediction cache | Open |
+| **P2** | Diversity-default ensemble + prediction cache | Done |
 | **P3** | Statistical `compare()` | Done |
 | **P4** | Pareto / best_under time-quality | Done |
 | **P5** | Tune glue redesign **or** deletion | Done |
-| **P6** | Plot pass aligned to P1–P4 | Open |
+| **P6** | Plot pass aligned to P1–P4 | Done |
 
 Parallelism: P0 first. P1 can start immediately after. P2 depends on similarity + cached preds (partially exists). P3 reads fold scores (exists). P4 is small and can slip between larger phases. P5 last among core so compare/error can support tuned deltas. P6 continuously skims off P1–P4.
 

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -16,6 +16,7 @@ from ..utils.estimate import element_to_list_maybe
 
 try:
     import plotly.express as px
+    import plotly.graph_objects as go
     from plotly.graph_objs._figure import Figure
     from plotly.subplots import make_subplots
 except ImportError as e:
@@ -739,3 +740,175 @@ class PoniardPlotFactory:
         )
         self._apply_layout(plot_array)
         return plot_array
+
+    def error_lift_bars(
+        self,
+        lift_by_target: pd.DataFrame | None = None,
+        estimator_names: str | Sequence[str] | None = None,
+        top_n: int | None = None,
+    ) -> Figure:
+        """Bar chart of error lift by target class or bin.
+
+        Lift = error_rate / global_error_rate. Values > 1 indicate the
+        class/bin is over-represented in errors.
+
+        Parameters
+        ----------
+        lift_by_target :
+            From ``ErrorReport.lift_by_target``. If None, computes it from
+            the estimator's last ``ErrorAnalyzer.analyze()`` call (requires
+            ``ErrorAnalyzer`` to have been run).
+        estimator_names :
+            Not used for this plot (lift is cross-estimator). Kept for
+            API consistency.
+        top_n :
+            Show only the top N classes/bins by lift. Default None (all).
+
+        Returns
+        -------
+        Figure
+            Plotly bar chart.
+        """
+        if lift_by_target is None:
+            raise ValueError(
+                "lift_by_target must be provided. "
+                "Run ErrorAnalyzer.from_poniard(clf).analyze(X, y) first, "
+                "then pass report.lift_by_target."
+            )
+        df = lift_by_target.copy()
+        if "lift" not in df.columns:
+            raise ValueError("lift_by_target must contain a 'lift' column.")
+        df = df.reset_index()
+        index_name = df.columns[0]
+        if top_n:
+            df = df.nlargest(top_n, "lift")
+        df = df.sort_values("lift", ascending=True)
+
+        fig = px.bar(
+            df,
+            x="lift",
+            y=index_name,
+            orientation="h",
+            title="Error lift by target (lift > 1 = over-represented in errors)",
+            hover_data={"lift": ":.2f", "error_rate": ":.3f"},
+            **self._px_kwargs(),
+        )
+        fig.add_vline(x=1.0, line_dash="dash", line_color="gray")
+        self._apply_layout(fig)
+        return fig
+
+    def similarity_heatmap(
+        self,
+        X: pd.DataFrame | np.ndarray | None = None,
+        y: pd.Series | np.ndarray | None = None,
+        on_errors: bool = True,
+    ) -> Figure:
+        """Heatmap of pairwise prediction similarity between estimators.
+
+        Parameters
+        ----------
+        X :
+            Features. Required to compute predictions.
+        y :
+            Target. Required to compute predictions.
+        on_errors :
+            Whether to compute similarity on prediction errors. Default True.
+
+        Returns
+        -------
+        Figure
+            Plotly heatmap.
+        """
+        if X is None:
+            X = self._X
+        if y is None:
+            y = self._y
+        sim = self._estimator.get_predictions_similarity(X=X, y=y, on_errors=on_errors)
+        labels = "error" if on_errors else "prediction"
+        fig = px.imshow(
+            sim,
+            text_auto=".2f",
+            title=f"Pairwise {labels} similarity between estimators",
+            zmin=0,
+            zmax=1,
+            color_continuous_scale="RdBu_r",
+            template=self._template,
+        )
+        fig.update_layout(
+            xaxis_title="Estimator",
+            yaxis_title="Estimator",
+        )
+        self._apply_layout(fig)
+        return fig
+
+    def time_quality_scatter(
+        self,
+        metric: str | None = None,
+        time_col: str = "fit_time",
+    ) -> Figure:
+        """Scatter plot of metric vs training/inference time.
+
+        Highlights the Pareto-optimal front.
+
+        Parameters
+        ----------
+        metric :
+            Metric column from ``get_results()``. If None, uses the first
+            (primary) metric.
+        time_col :
+            Column name for time. Default ``"fit_time"``.
+
+        Returns
+        -------
+        Figure
+            Plotly scatter plot.
+        """
+        from sklearn.dummy import DummyClassifier, DummyRegressor
+
+        results = self._estimator.get_results()
+        if metric is None:
+            metric = results.columns[0]
+        if metric not in results.columns:
+            raise ValueError(f"Metric '{metric}' not found.")
+        if time_col not in results.columns:
+            raise ValueError(f"Time column '{time_col}' not found.")
+
+        pareto = self._estimator.pareto(metric=metric, time_col=time_col)
+        pareto_names = set(pareto.index)
+
+        dummy = set()
+        for name, pipeline in self._estimator.pipelines.items():
+            if isinstance(pipeline._final_estimator, (DummyClassifier, DummyRegressor)):
+                dummy.add(name)
+
+        df = results[[metric, time_col]].copy()
+        df["type"] = "model"
+        df.loc[df.index.isin(pareto_names), "type"] = "pareto"
+        df.loc[df.index.isin(dummy), "type"] = "dummy"
+        df = df.reset_index().rename(columns={"index": "estimator"})
+
+        color_map = {"model": "#636EFA", "pareto": "#EF553B", "dummy": "#AB63FA"}
+        fig = px.scatter(
+            df,
+            x=time_col,
+            y=metric,
+            color="type",
+            hover_data={"estimator": True, metric: ":.3f", time_col: ":.4f"},
+            title=f"Metric vs {time_col} (Pareto front in red)",
+            color_discrete_map=color_map,
+            **self._px_kwargs(),
+        )
+        # Draw Pareto front line
+        pareto_line = pareto.sort_values(time_col)
+        fig.add_trace(
+            go.Scatter(
+                x=pareto_line[time_col],
+                y=pareto_line[metric],
+                mode="lines",
+                line=dict(color="red", width=1, dash="dot"),
+                showlegend=False,
+                hoverinfo="skip",
+            )
+        )
+        self._apply_layout(fig)
+        return fig

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -125,3 +125,66 @@ class TestRegressorPlots:
             "LinearRegression"
         )
         assert isinstance(fig, go.Figure)
+
+
+class TestNewPlots:
+    def test_error_lift_bars(self, clf_setup):
+        from poniard.error_analysis import ErrorAnalyzer
+
+        X, y, clf = clf_setup
+        ea = ErrorAnalyzer.from_poniard(clf)
+        report = ea.analyze(X=X, y=y)
+        fig = PoniardPlotFactory(X, y, clf).error_lift_bars(
+            lift_by_target=report.lift_by_target
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_error_lift_bars_top_n(self, clf_setup):
+        from poniard.error_analysis import ErrorAnalyzer
+
+        X, y, clf = clf_setup
+        ea = ErrorAnalyzer.from_poniard(clf)
+        report = ea.analyze(X=X, y=y)
+        fig = PoniardPlotFactory(X, y, clf).error_lift_bars(
+            lift_by_target=report.lift_by_target, top_n=1
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_error_lift_bars_requires_data(self, clf_setup):
+        X, y, clf = clf_setup
+        with pytest.raises(ValueError, match="lift_by_target"):
+            PoniardPlotFactory(X, y, clf).error_lift_bars()
+
+    def test_similarity_heatmap(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).similarity_heatmap(X, y)
+        assert isinstance(fig, go.Figure)
+
+    def test_similarity_heatmap_on_predictions(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).similarity_heatmap(
+            X, y, on_errors=False
+        )
+        assert isinstance(fig, go.Figure)
+
+    def test_similarity_heatmap_regressor(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).similarity_heatmap(X, y)
+        assert isinstance(fig, go.Figure)
+
+    def test_time_quality_scatter(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).time_quality_scatter()
+        assert isinstance(fig, go.Figure)
+
+    def test_time_quality_scatter_regressor(self, reg_setup):
+        X, y, reg = reg_setup
+        fig = PoniardPlotFactory(X, y, reg).time_quality_scatter()
+        assert isinstance(fig, go.Figure)
+
+    def test_time_quality_scatter_custom_metric(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).time_quality_scatter(
+            metric="test_accuracy"
+        )
+        assert isinstance(fig, go.Figure)


### PR DESCRIPTION
## Summary

P6 — plot pass aligned with P1–P4. Three new high-value diagnostic plots:

### error_lift_bars()
Bar chart of error lift by target class/bin from `ErrorReport.lift_by_target`. Lift > 1 means the class is over-represented in errors. Dashed line at lift=1 for reference.

```python
from poniard.error_analysis import ErrorAnalyzer
ea = ErrorAnalyzer.from_poniard(clf)
report = ea.analyze(X, y)
PoniardPlotFactory(X, y, clf).error_lift_bars(report.lift_by_target)
```

### similarity_heatmap()
Pairwise prediction-error similarity between estimators via `get_predictions_similarity(on_errors=True)`. Shows which models fail on the same samples (useful for diversity-aware ensembling).

```python
PoniardPlotFactory(X, y, clf).similarity_heatmap(X, y)
```

### time_quality_scatter()
Metric vs fit_time scatter with the Pareto-optimal front highlighted in red. Dummies shown in purple.

```python
PoniardPlotFactory(X, y, clf).time_quality_scatter()
```

Kept: partial dependence, all existing plots.

## Tests
- 210 tests pass, ruff clean
- 9 new tests covering all new plots (classifier, regressor, custom metric, top_n, etc.)
