### PR TITLE
fix: P0 correctness bugs (error analysis, plotting, fitted tracking)

### DIFF
--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -276,16 +276,22 @@ class ErrorAnalyzer:
         exclude_correct: bool = True,
         error_quantile: float = 0.1,
     ) -> pd.DataFrame:
+        classes = np.unique(y)
         data = {"y": y, "prediction": predictions}
-        data.update({f"proba_{i}": probas[:, i] for i in range(len(np.unique(y)))})
+        data.update({f"proba_{i}": probas[:, i] for i in range(len(classes))})
         errors = pd.DataFrame(data)
         if exclude_correct:
             errors = errors.query("y != prediction")
-        errors = errors.assign(
-            truth_proba=errors.apply(
-                lambda row: row[f"proba_{int(row['y'])}"], axis=1
-            )
+        # Map each ground-truth label to its positional class index so any
+        # label encoding (strings, non-contiguous ints, ...) works. proba
+        # columns are indexed positionally, in np.unique order, matching
+        # sklearn's ``classes_`` ordering.
+        proba_matrix = np.column_stack(
+            [errors[f"proba_{i}"].to_numpy() for i in range(len(classes))]
         )
+        class_positions = np.searchsorted(classes, errors["y"].to_numpy())
+        truth_proba = proba_matrix[np.arange(len(errors)), class_positions]
+        errors = errors.assign(truth_proba=truth_proba)
         errors = errors.assign(error=(1 - errors["truth_proba"]).abs())
         return errors.sort_values("error", ascending=False)
 

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -749,6 +749,11 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         for new_estimator in new_estimators.values():
             self._pass_instance_attrs(new_estimator)
         self._added_estimators.update(new_estimators)
+        self._removed_estimators = [
+            name
+            for name in self._removed_estimators
+            if name not in new_estimators
+        ]
         self.pipelines.update({
             name: self._make_pipeline(name, estimator)
             for name, estimator in new_estimators.items()
@@ -782,15 +787,18 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         if len(pruned_estimators) == 0:
             raise ValueError("Cannot remove all estimators.")
         self.pipelines = pruned_estimators
-        if drop_results and hasattr(self, "_means"):
-            self._means = self._means.loc[~self._means.index.isin(estimator_names)]
-            self._stds = self._stds.loc[~self._stds.index.isin(estimator_names)]
-            self._experiment_results = {
-                k: v
-                for k, v in self._experiment_results.items()
-                if k not in estimator_names
-            }
-            self._process_long_results()
+        if drop_results:
+            if hasattr(self, "_fitted_pipeline_names"):
+                self._fitted_pipeline_names.difference_update(estimator_names)
+            if hasattr(self, "_means"):
+                self._means = self._means.loc[~self._means.index.isin(estimator_names)]
+                self._stds = self._stds.loc[~self._stds.index.isin(estimator_names)]
+                self._experiment_results = {
+                    k: v
+                    for k, v in self._experiment_results.items()
+                    if k not in estimator_names
+                }
+                self._process_long_results()
         return self
 
     def get_estimator(

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 __all__ = ["PoniardPlotFactory"]
 
+import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+from sklearn.base import clone
 from sklearn.inspection import partial_dependence, permutation_importance
 from sklearn.metrics import auc, confusion_matrix, roc_curve
 
@@ -132,18 +134,20 @@ class PoniardPlotFactory:
             results = results.loc[results["Metric"].str.contains("test", case=False)]
         if exclude_dummy:
             results = results.loc[~results["Model"].str.contains("Dummy")]
+        metric_names = None
         if metrics:
-            metrics = element_to_list_maybe(metrics)
-            metrics = "|".join(metrics)
-            results = results.loc[results["Metric"].str.contains(metrics)]
+            metric_names = element_to_list_maybe(metrics)
+            pattern = "|".join(re.escape(m) for m in metric_names)
+            results = results.loc[results["Metric"].str.contains(pattern)]
         if not show_means:
             results = results.loc[~(results["Type"] == "Mean")]
         height = 100 * results["Model"].nunique()
+        facet_by_metric = metric_names is None or len(metric_names) > 1
         if facet == "col":
             facet_row = None
-            facet_col = "Metric" if not metrics or len(metrics) > 1 else None
+            facet_col = "Metric" if facet_by_metric else None
         else:
-            facet_row = "Metric" if not metrics or len(metrics) > 1 else None
+            facet_row = "Metric" if facet_by_metric else None
             facet_col = None
         if kind == "strip":
             fig = px.strip(
@@ -266,7 +270,7 @@ class PoniardPlotFactory:
             self._X, self._y
         )
         scoring = self._estimator._first_scorer(sklearn_scorer=True)
-        estimator = self._estimator.pipelines[estimator_name]
+        estimator = clone(self._estimator.pipelines[estimator_name])
         estimator.fit(X_train, y_train)
         raw_importances = permutation_importance(
             estimator,
@@ -497,7 +501,7 @@ class PoniardPlotFactory:
         """
         y = self._y
         X = self._X
-        estimator = self._estimator.pipelines[estimator_name]
+        estimator = clone(self._estimator.pipelines[estimator_name])
         estimator.fit(X, y)
         partial_dep = partial_dependence(
             estimator, X, features=[feature], kind="average", **kwargs

--- a/tests/test_add_remove.py
+++ b/tests/test_add_remove.py
@@ -56,3 +56,14 @@ def test_get(include_preprocessor, output_type):
         "RandomForestClassifier", include_preprocessor=include_preprocessor
     )
     assert isinstance(estimator, output_type)
+
+
+def test_remove_then_readd_refits_estimator():
+    y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1])
+    x = pd.DataFrame(np.random.normal(size=(len(y), 5)))
+    clf = PoniardClassifier(estimators=[RandomForestClassifier()]).setup(x, y)
+    clf.fit(x, y)
+    clf.remove_estimators(["RandomForestClassifier"])
+    clf.add_estimators({"RandomForestClassifier": RandomForestClassifier()})
+    clf.fit(x, y)
+    assert "RandomForestClassifier" in clf.get_results().index

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -526,3 +526,37 @@ def test_repr():
     ea = ErrorAnalyzer(task="classification")
     r = repr(ea)
     assert "ErrorAnalyzer" in r
+
+
+def test_rank_errors_multiclass_non_integer_labels():
+    """String class labels must not crash error ranking; proba lookup is positional."""
+    ea = ErrorAnalyzer(task="classification")
+    ea.type_of_target = "multiclass"
+    y = np.array(["cat", "dog", "mouse", "cat", "dog"])
+    preds = np.array(["cat", "cat", "mouse", "dog", "dog"])
+    probas = np.array(
+        [
+            [0.8, 0.1, 0.1],
+            [0.6, 0.3, 0.1],
+            [0.1, 0.1, 0.8],
+            [0.5, 0.4, 0.1],
+            [0.1, 0.8, 0.1],
+        ]
+    )
+    ranked = ea._rank_errors_multiclass(y, preds, probas)
+    # Only rows 1 and 3 are misclassified; row 1 (dog, truth-proba 0.3) ranks first.
+    assert list(ranked.index) == [1, 3]
+    assert list(ranked["error"]) == pytest.approx([0.7, 0.5])
+
+
+def test_analyze_multiclass_string_labels():
+    """End-to-end error analysis must work with non-integer class labels."""
+    X = pd.DataFrame(np.random.normal(size=(N, 2)))
+    y = pd.Series(np.random.choice(["a", "b", "c"], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    report = ErrorAnalyzer.from_poniard(clf).analyze(X, y)
+    assert set(report.summary.index) == {"lr"}

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -40,6 +40,13 @@ class TestClassifierPlots:
         fig = PoniardPlotFactory(X, y, clf).metrics()
         assert isinstance(fig, go.Figure)
 
+    def test_metrics_single_metric_no_facet(self, clf_setup):
+        X, y, clf = clf_setup
+        fig = PoniardPlotFactory(X, y, clf).metrics(metrics="test_accuracy")
+        assert isinstance(fig, go.Figure)
+        # A single explicitly-selected metric must not produce a metric facet.
+        assert fig.layout.grid is None or fig.layout.grid.columns is None
+
     def test_metrics_bar(self, clf_setup):
         X, y, clf = clf_setup
         fig = PoniardPlotFactory(X, y, clf).metrics(kind="bar")

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -192,3 +192,26 @@ def test_custom_sklearn_preprocessor_outputs_pandas_without_global_set_config():
         assert isinstance(out, pd.DataFrame)
     finally:
         set_config(transform_output="default")
+
+
+def test_plot_factory_does_not_fit_stored_pipelines():
+    """Plot methods that need a fitted model fit a clone, never the stored pipeline."""
+    from sklearn.linear_model import LogisticRegression
+
+    from poniard.plot import PoniardPlotFactory
+
+    X = pd.DataFrame(np.random.normal(size=(40, 3)), columns=list("abc"))
+    X["s"] = np.random.choice(["x", "y", "z"], size=40)
+    y = pd.Series(np.random.choice([0, 1], size=40))
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
+    clf.setup(X, y)
+    clf.fit(X, y)
+    stored = clf.pipelines["LogisticRegression"]
+    assert not hasattr(stored, "classes_")
+
+    plotter = PoniardPlotFactory(X, y, clf)
+    plotter.permutation_importance("LogisticRegression", n_repeats=1)
+    assert not hasattr(clf.pipelines["LogisticRegression"], "classes_")
+
+    plotter.partial_dependence("LogisticRegression", feature=0)
+    assert not hasattr(clf.pipelines["LogisticRegression"], "classes_")


### PR DESCRIPTION
## Phase 0 of the tech debt roadmap (TECH_DEBT.md)

Fixes all four P0 verified bugs, each with a regression test.

### 1. Multiclass error ranking crashes on non-integer labels
`error_analysis.py` — `_rank_errors_multiclass` used `int(row['y'])` to index the
proba column, assuming `0..n-1` integer labels. String labels crashed with
`ValueError: invalid literal for int()`; non-contiguous int labels silently indexed
the wrong column. Now maps labels positionally via `np.searchsorted` over
`np.unique(y)` (same order as sklearn `classes_`), which is also vectorized (no more
row-wise `apply`).

### 2. Plotting silently fits the stored pipelines
`plot_factory.py` — `permutation_importance` and `partial_dependence` called `.fit()`
on the pipeline object stored in `estimator.pipelines[name]`, not a clone. After
drawing a plot, the pipeline was fitted on a random 80/20 split — a side effect the
project explicitly polices (ROADMAP §7.1). Both now fit a `sklearn.base.clone`.
Extended `tests/test_side_effects.py` to cover the plotting surface.

### 3. Remove → re-add an estimator → never refit / never reported
`estimators/core.py` — two related defects:
- `_removed_estimators` was never cancelled on re-add, so the next `_build_pipelines()`
  (every `fit()`) popped the re-added estimator again → `get_results()` silently
  missing it.
- `remove_estimators(drop_results=True)` kept the name in `_fitted_pipeline_names`.
Both fixed; the pending-removal list is cleared on re-add and fitted tracking is
dropped for removed names.

### 4. `metrics()` faceting broken for a single metric
`plot_factory.py` — `metrics = "|".join(metrics)` overwrote the list, then
`len(metrics) > 1` measured string length (always true) → single-metric plots got a
pointless facet. Facet decision now uses the pre-join list length; metric names are
`re.escape`d before use in `str.contains`.

### Verification
- `uv run ruff check poniard/ tests/` — clean
- `uv run pytest` — **215 passed** (210 baseline + 5 new regression tests)