### PR TITLE
refactor: decouple satellites, stop mutating user objects (Phase 4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Lint
         run: uv run ruff check poniard/ tests/
 
-      - name: Test
-        run: uv run pytest
+      - name: Format check
+        run: uv run ruff format --check poniard/ tests/
+
+      - name: Test (with coverage gate)
+        run: uv run pytest --cov=poniard --cov-report=term-missing --cov-fail-under=85
 
   publish:
     if: startsWith(github.ref, 'refs/tags')

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix]

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -13,9 +13,9 @@ from sklearn.inspection import permutation_importance
 from sklearn.model_selection import train_test_split
 
 if TYPE_CHECKING:
-    from poniard.estimators.core import PoniardBaseEstimator
-from ..preprocessing import PoniardPreprocessor
-from ..utils.estimate import element_to_list_maybe, get_target_info
+    from poniard.estimators.core import EstimatorView
+from ..preprocessing import infer_feature_types
+from ..utils.estimate import coerce_input, element_to_list_maybe, get_target_info
 from ..utils.utils import non_default_repr
 
 
@@ -96,9 +96,9 @@ class ErrorAnalyzer:
     """
 
     def __init__(self, task: str):
-        self._init_params = {k: v for k, v in locals().items() if k != "self"}
+        self._init_params = {"task": task}
         self.task = task
-        self._poniard: PoniardBaseEstimator | None = None
+        self._poniard: EstimatorView | None = None
 
     @property
     def _has_poniard(self) -> bool:
@@ -107,7 +107,7 @@ class ErrorAnalyzer:
     @classmethod
     def from_poniard(
         cls,
-        poniard: PoniardBaseEstimator,
+        poniard: EstimatorView,
         estimator_names: str | Sequence[str] | None = None,
     ) -> ErrorAnalyzer:
         """Use a Poniard instance to instantiate `ErrorAnalyzer`.
@@ -132,15 +132,8 @@ class ErrorAnalyzer:
         error_analysis = cls(task=poniard.poniard_task)
         error_analysis._poniard = poniard
         if estimator_names is None:
-            from sklearn.dummy import DummyClassifier, DummyRegressor
-
             estimator_names = [
-                name
-                for name in poniard.pipelines
-                if not isinstance(
-                    poniard.pipelines[name]._final_estimator,
-                    (DummyClassifier, DummyRegressor),
-                )
+                name for name in poniard.pipelines if name not in poniard._dummy_names()
             ]
         error_analysis.estimator_names = element_to_list_maybe(estimator_names)
         error_analysis.type_of_target = poniard.target_info["type_"]
@@ -520,11 +513,9 @@ class ErrorAnalyzer:
         if self._has_poniard:
             feature_types = self._poniard.feature_types.items()
         else:
-            feature_types = (
-                PoniardPreprocessor(task="placeholder")
-                .build(X, np.zeros((X.shape[0],)))
-                .feature_types.items()
-            )
+            feature_types = infer_feature_types(
+                coerce_input(X), numeric_threshold=0.1, cardinality_threshold=20
+            ).items()
         inverted_feature_types = {}
         for k, v in feature_types:
             for i in v:

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -148,14 +148,10 @@ class ErrorAnalyzer:
 
     def _compute_predictions(self, X, y):
         """Compute cross-validated predictions for the selected estimators."""
-        predictions = self._poniard.predict(
-            X=X, y=y, estimator_names=self.estimator_names
-        )
+        predictions = self._poniard.predict(X=X, y=y, estimator_names=self.estimator_names)
         probas = None
         if self.type_of_target in ["binary", "multilabel-indicator", "multiclass"]:
-            probas = self._poniard.predict_proba(
-                X=X, y=y, estimator_names=self.estimator_names
-            )
+            probas = self._poniard.predict_proba(X=X, y=y, estimator_names=self.estimator_names)
         return predictions, probas
 
     def rank_errors(
@@ -204,9 +200,7 @@ class ErrorAnalyzer:
         """
         if self._has_poniard:
             if X is None or y is None:
-                raise ValueError(
-                    "X and y must be provided when using `from_poniard`."
-                )
+                raise ValueError("X and y must be provided when using `from_poniard`.")
             predictions, probas = self._compute_predictions(X, y)
             ranked_errors = {}
             for estimator in self.estimator_names:
@@ -220,13 +214,9 @@ class ErrorAnalyzer:
                 )
             return ranked_errors
         self.type_of_target = get_target_info(y, task=self.task)["type_"]
-        return self._rank_single(
-            y, predictions, probas, exclude_correct, error_quantile
-        )
+        return self._rank_single(y, predictions, probas, exclude_correct, error_quantile)
 
-    def _rank_single(
-        self, y, predictions, probas, exclude_correct, error_quantile
-    ) -> pd.DataFrame:
+    def _rank_single(self, y, predictions, probas, exclude_correct, error_quantile) -> pd.DataFrame:
         """Rank errors for a single set of predictions."""
         return self._target_redirect(self.type_of_target)(
             y, predictions, probas, exclude_correct, error_quantile
@@ -314,12 +304,8 @@ class ErrorAnalyzer:
             truth = truth.loc[keep]
             pro = pro.loc[keep]
         per_label = np.abs(truth.values - pro.values)
-        errors = errors.assign(
-            **{f"error_{i}": per_label[:, i] for i in range(n_labels)}
-        )
-        errors = errors.assign(
-            error=errors[[f"error_{i}" for i in range(n_labels)]].mean(axis=1)
-        )
+        errors = errors.assign(**{f"error_{i}": per_label[:, i] for i in range(n_labels)})
+        errors = errors.assign(error=errors[[f"error_{i}" for i in range(n_labels)]].mean(axis=1))
         return errors.sort_values("error", ascending=False)
 
     def _rank_errors_continuous(
@@ -360,17 +346,12 @@ class ErrorAnalyzer:
                 for i in range(n_targets)
             }
             flagged = pd.DataFrame(
-                {
-                    i: per_target[f"error_{i}"] > thresholds[i]
-                    for i in range(n_targets)
-                }
+                {i: per_target[f"error_{i}"] > thresholds[i] for i in range(n_targets)}
             )
             keep = flagged.any(axis=1)
             errors = errors.loc[keep]
             per_target = per_target.loc[keep]
-        errors = pd.concat(
-            [errors, per_target.assign(error=per_target.mean(axis=1))], axis=1
-        )
+        errors = pd.concat([errors, per_target.assign(error=per_target.mean(axis=1))], axis=1)
         return errors.sort_values("error", ascending=False)
 
     @staticmethod
@@ -395,10 +376,7 @@ class ErrorAnalyzer:
         if isinstance(errors, pd.DataFrame):
             errors = {"model": errors}
         concatenated = pd.concat(
-            [
-                frame.assign(estimator=estimator)
-                for estimator, frame in errors.items()
-            ]
+            [frame.assign(estimator=estimator) for estimator, frame in errors.items()]
         ).reset_index()
         merged = (
             concatenated.groupby("index")
@@ -454,10 +432,7 @@ class ErrorAnalyzer:
             y_errors = y_errors.assign(bins=bins)
             target_names = "bins"
         elif type_of_target == "continuous-multioutput":
-            bins = {
-                f"bin_{target}": pd.qcut(y[target], q=reg_bins)
-                for target in range(y.shape[1])
-            }
+            bins = {f"bin_{target}": pd.qcut(y[target], q=reg_bins) for target in range(y.shape[1])}
             y = y.assign(**bins)
             y_errors = y_errors.assign(**bins)
             target_names = list(bins.keys())
@@ -465,12 +440,8 @@ class ErrorAnalyzer:
             raise NotImplementedError("Type of target could not be determined.")
         errors_dist = y_errors.groupby(target_names, observed=True).size()
         target_dist = y.groupby(target_names, observed=True).size()
-        output = pd.DataFrame(
-            {"error_count": errors_dist, "target_count": target_dist}
-        ).fillna(0)
-        output["error_rate"] = output["error_count"] / output[
-            "target_count"
-        ].replace(0, np.nan)
+        output = pd.DataFrame({"error_count": errors_dist, "target_count": target_dist}).fillna(0)
+        output["error_rate"] = output["error_count"] / output["target_count"].replace(0, np.nan)
         output = output.sort_values("error_count", ascending=False)
         return output
 
@@ -524,8 +495,7 @@ class ErrorAnalyzer:
             feature_types = (
                 PoniardPreprocessor(task="placeholder")
                 .build(X, np.zeros((X.shape[0],)))
-                .feature_types
-                .items()
+                .feature_types.items()
             )
         inverted_feature_types = {}
         for k, v in feature_types:
@@ -537,16 +507,10 @@ class ErrorAnalyzer:
         columns = [col for col in X.columns if col != "error"]
 
         if features:
-            features_idx = {
-                i
-                for i, col in enumerate(columns)
-                if col in features or i in features
-            }
+            features_idx = {i for i, col in enumerate(columns) if col in features or i in features}
         elif estimator_name:
             if not self._has_poniard:
-                raise ValueError(
-                    "`estimator_name` is only valid when using `from_poniard`."
-                )
+                raise ValueError("`estimator_name` is only valid when using `from_poniard`.")
             if y is None:
                 raise ValueError("`y` must be provided when `estimator_name` is used.")
             importances = self._compute_permutation_importances(X[columns], y, estimator_name)
@@ -573,9 +537,7 @@ class ErrorAnalyzer:
                 crosstab.columns = ["correct", "errors"]
                 total = crosstab["correct"] + crosstab["errors"]
                 crosstab = crosstab.assign(
-                    error_rate=(
-                        crosstab["errors"] / total.replace(0, np.nan)
-                    ).fillna(0)
+                    error_rate=(crosstab["errors"] / total.replace(0, np.nan)).fillna(0)
                 )
                 summary[col] = crosstab
         return summary
@@ -666,9 +628,7 @@ class ErrorAnalyzer:
         if isinstance(ranked, pd.DataFrame):
             ranked = {"model": ranked}
         merged = self.merge_errors(ranked)
-        by_target = self.analyze_target(
-            errors_idx=merged.index, y=y, reg_bins=reg_bins
-        )
+        by_target = self.analyze_target(errors_idx=merged.index, y=y, reg_bins=reg_bins)
         by_feature = self.analyze_features(
             errors_idx=merged.index,
             X=X,
@@ -708,9 +668,7 @@ class ErrorAnalyzer:
         )
 
     @staticmethod
-    def _compute_lift_by_target(
-        by_target: pd.DataFrame, global_error_rate: float
-    ) -> pd.DataFrame:
+    def _compute_lift_by_target(by_target: pd.DataFrame, global_error_rate: float) -> pd.DataFrame:
         """Compute lift = error_rate / global_error_rate per class/bin."""
         if global_error_rate == 0:
             lift = by_target[["error_rate"]].copy()

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -147,11 +147,39 @@ class ErrorAnalyzer:
         return error_analysis
 
     def _compute_predictions(self, X, y):
-        """Compute cross-validated predictions for the selected estimators."""
-        predictions = self._poniard.predict(X=X, y=y, estimator_names=self.estimator_names)
-        probas = None
-        if self.type_of_target in ["binary", "multilabel-indicator", "multiclass"]:
-            probas = self._poniard.predict_proba(X=X, y=y, estimator_names=self.estimator_names)
+        """Compute cross-validated predictions and probabilities for the selected estimators.
+
+        For binary and multiclass targets, hard predictions are derived from the
+        predicted probabilities (argmax over ``np.unique(y)`` order, which matches
+        sklearn's ``classes_``), so only a single cross-validation pass is needed.
+        Estimators without ``predict_proba`` fall back to ``predict``.
+        """
+        if self.type_of_target in ["binary", "multiclass"]:
+            classes = np.unique(y)
+            proba_support = [
+                name
+                for name in self.estimator_names
+                if hasattr(self._poniard.pipelines[name], "predict_proba")
+            ]
+            non_support = [name for name in self.estimator_names if name not in proba_support]
+            if proba_support:
+                probas = self._poniard.predict_proba(X=X, y=y, estimator_names=proba_support)
+            else:
+                probas = {}
+            predictions = {
+                name: classes[np.argmax(proba, axis=1)] for name, proba in probas.items()
+            }
+            if non_support:
+                predictions.update(self._poniard.predict(X=X, y=y, estimator_names=non_support))
+                probas.update(
+                    {name: np.full((len(y), len(classes)), np.nan) for name in non_support}
+                )
+        else:
+            predictions = self._poniard.predict(X=X, y=y, estimator_names=self.estimator_names)
+            if self.type_of_target == "multilabel-indicator":
+                probas = self._poniard.predict_proba(X=X, y=y, estimator_names=self.estimator_names)
+            else:
+                probas = None
         return predictions, probas
 
     def rank_errors(

--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ['PoniardClassifier']
+__all__ = ["PoniardClassifier"]
 
 from collections.abc import Callable
 from typing import Sequence
@@ -85,18 +85,14 @@ class PoniardClassifier(PoniardBaseEstimator):
     @property
     def _default_estimators(self) -> list[ClassifierMixin]:
         return [
-            LogisticRegression(
-                random_state=self.random_state, verbose=self.verbose, max_iter=5000
-            ),
+            LogisticRegression(random_state=self.random_state, verbose=self.verbose, max_iter=5000),
             GaussianNB(),
             KNeighborsClassifier(),
             DecisionTreeClassifier(random_state=self.random_state),
             RandomForestClassifier(
                 random_state=self.random_state, verbose=self.verbose, n_jobs=self.n_jobs
             ),
-            HistGradientBoostingClassifier(
-                random_state=self.random_state, verbose=self.verbose
-            ),
+            HistGradientBoostingClassifier(random_state=self.random_state, verbose=self.verbose),
         ]
 
     def _build_metrics(self) -> dict[str, Callable] | list[str]:
@@ -130,9 +126,7 @@ class PoniardClassifier(PoniardBaseEstimator):
         cv = self.cv or 5
         if isinstance(cv, int):
             if self.target_info["type_"] in ("binary", "multiclass"):
-                return StratifiedKFold(
-                    n_splits=cv, shuffle=True, random_state=self.random_state
-                )
+                return StratifiedKFold(n_splits=cv, shuffle=True, random_state=self.random_state)
             else:
                 return KFold(n_splits=cv, shuffle=True, random_state=self.random_state)
         else:

--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -78,6 +78,11 @@ class PoniardClassifier(PoniardBaseEstimator):
         )
 
     @property
+    def poniard_task(self) -> str:
+        """Return the task name."""
+        return "classification"
+
+    @property
     def _default_estimators(self) -> list[ClassifierMixin]:
         return [
             LogisticRegression(

--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 __all__ = ["PoniardClassifier"]
 
-from collections.abc import Callable
-from typing import Sequence
+from collections.abc import Callable, Sequence
 
-from sklearn.base import ClassifierMixin, TransformerMixin
+from sklearn.base import ClassifierMixin, TransformerMixin, clone
 from sklearn.ensemble import (
     HistGradientBoostingClassifier,
     RandomForestClassifier,
@@ -130,5 +129,7 @@ class PoniardClassifier(PoniardBaseEstimator):
             else:
                 return KFold(n_splits=cv, shuffle=True, random_state=self.random_state)
         else:
+            if isinstance(cv, (BaseCrossValidator, BaseShuffleSplit)):
+                cv = clone(cv, safe=False)
             self._pass_instance_attrs(cv)
             return cv

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -121,23 +121,32 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         self._added_estimators = {}
         self._removed_estimators = []
 
+        # State is initialized here so every attribute exists from construction;
+        # methods mutate it instead of creating attributes implicitly. Derived
+        # state (means/stds, long results) is None until `fit` produces it.
+        self._cv_results = {}
+        self._prediction_cache = {}
+        self._means = None
+        self._stds = None
+        self._long_results = None
+        self._fold_sizes = None
+        self._tuning_results = {}
+        self._fitted_pipeline_names = set()
+        self.pipelines = {}
+        self.preprocessor = None
+        self.feature_types = {}
+        self._poniard_preprocessor = None
+        self.target_info = None
+        self.show_info = None
+
     @property
-    def poniard_task(self) -> str | None:
-        """Check whether self is a Poniard regressor or classifier.
+    @abstractmethod
+    def poniard_task(self) -> str:
+        """Return the task name: "regression" or "classification".
 
-        Returns
-        -------
-        str | None
-            "regression", "classification" or None
+        Implemented by `PoniardClassifier` and `PoniardRegressor`, so no
+        isinstance sniffing or deferred imports are needed.
         """
-        from poniard import PoniardClassifier, PoniardRegressor
-
-        if isinstance(self, PoniardRegressor):
-            return "regression"
-        elif isinstance(self, PoniardClassifier):
-            return "classification"
-        else:
-            return None
 
     def setup(
         self,
@@ -222,7 +231,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         shape = self.target_info["shape"]
         nunique = self.target_info["nunique"]
         main_metric = self._first_scorer(sklearn_scorer=False)
-        if hasattr(self, "_poniard_preprocessor"):
+        if self._poniard_preprocessor is not None:
             num_thresh = self._poniard_preprocessor.numeric_threshold
             cat_thresh = self._poniard_preprocessor.cardinality_threshold
         if _has_ipython:
@@ -239,7 +248,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                              """
                 )
             )
-            if hasattr(self, "_poniard_preprocessor"):
+            if self._poniard_preprocessor is not None:
                 display(
                     HTML(
                         f""" <h3>Feature type inference</h3>
@@ -266,7 +275,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 sep="\n",
                 end="\n\n",
             )
-            if hasattr(self, "_poniard_preprocessor"):
+            if self._poniard_preprocessor is not None:
                 print(
                     "Thresholds",
                     "----------",
@@ -450,12 +459,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
         # Cross-validate
         results = {}
-        filtered_pipelines = {
-            name: pipeline
-            for name, pipeline in self.pipelines.items()
-            if name not in self._fitted_pipeline_names
-        }
-        pbar = tqdm(filtered_pipelines.items(), leave=self._tqdm_leave)
+        pbar = tqdm(self.pipelines.items(), leave=self._tqdm_leave)
         for i, (name, pipeline) in enumerate(pbar):
             pbar.set_description(f"{name}")
             with warnings.catch_warnings():
@@ -477,10 +481,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             self._fitted_pipeline_names.add(name)
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
-        if hasattr(self, "_experiment_results"):
-            self._experiment_results.update(results)
-        else:
-            self._experiment_results = results
+        self._cv_results.update(results)
 
         # Store fold sizes for per-sample time computation
         cv = self.cv
@@ -498,7 +499,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     ) -> dict[str, np.ndarray]:
         """Helper method for predicting targets or target probabilities with cross validation.
         Accepts predict, predict_proba, predict_log_proba or decision_function."""
-        if not hasattr(self, "cv"):
+        if not self.pipelines:
             raise ValueError("`setup` must be called before `predict`.")
         estimator_names = element_to_list_maybe(estimator_names)
         if not estimator_names:
@@ -526,14 +527,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 result = np.empty(y.shape)
                 result[:] = np.nan
             results.update({name: result})
-
-            if not hasattr(self, "_experiment_results"):
-                self._experiment_results = {}
-                self._experiment_results.update({name: {method: result}})
-            elif name not in self._experiment_results:
-                self._experiment_results.update({name: {method: result}})
-            else:
-                self._experiment_results[name][method] = result
+            self._prediction_cache[(name, method)] = result
 
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
@@ -788,14 +782,18 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             raise ValueError("Cannot remove all estimators.")
         self.pipelines = pruned_estimators
         if drop_results:
-            if hasattr(self, "_fitted_pipeline_names"):
-                self._fitted_pipeline_names.difference_update(estimator_names)
-            if hasattr(self, "_means"):
+            self._fitted_pipeline_names.difference_update(estimator_names)
+            self._prediction_cache = {
+                k: v
+                for k, v in self._prediction_cache.items()
+                if k[0] not in estimator_names
+            }
+            if self._means is not None:
                 self._means = self._means.loc[~self._means.index.isin(estimator_names)]
                 self._stds = self._stds.loc[~self._stds.index.isin(estimator_names)]
-                self._experiment_results = {
+                self._cv_results = {
                     k: v
-                    for k, v in self._experiment_results.items()
+                    for k, v in self._cv_results.items()
                     if k not in estimator_names
                 }
                 self._process_long_results()
@@ -905,11 +903,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str):
         """Get predictions (either predict, predict_proba or decision_function) for a given
         estimator or compute if not available."""
-        try:
-            return self._experiment_results[estimator_name][method]
-        except KeyError:
+        key = (estimator_name, method)
+        if key not in self._prediction_cache:
             self._predict(method=method, X=X, y=y, estimator_names=[estimator_name])
-            return self._experiment_results[estimator_name][method]
+        return self._prediction_cache[key]
 
     def __repr__(self):
         return non_default_repr(self)

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -41,7 +41,8 @@ from .ensemble import EnsembleMixin
 from .results import ResultsMixin
 from .tuning import TuningMixin
 
-__all__ = ['PoniardBaseEstimator']
+__all__ = ["PoniardBaseEstimator"]
+
 
 class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     """Base estimator that sets up all the functionality for the classifier and regressor.
@@ -92,10 +93,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
         self._init_params = {k: v for k, v in locals().items() if k != "self"}
         if metrics and (
-            (
-                isinstance(metrics, Sequence)
-                and not all(isinstance(m, str) for m in metrics)
-            )
+            (isinstance(metrics, Sequence) and not all(isinstance(m, str) for m in metrics))
             or (
                 isinstance(metrics, dict)
                 and not all(isinstance(m, str) for m in metrics.keys())
@@ -346,9 +344,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 pass
 
     @staticmethod
-    def _generate_estimator_name(
-        estimator, existing_names: set[str], all_estimators: list
-    ) -> str:
+    def _generate_estimator_name(estimator, existing_names: set[str], all_estimators: list) -> str:
         """Generate a name for an estimator.
 
         Default is the class name. If it clashes, append _2, _3, etc.
@@ -402,8 +398,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             self._pass_instance_attrs(estimator)
 
         pipelines = {
-            name: self._make_pipeline(name, estimator)
-            for name, estimator in estimators.items()
+            name: self._make_pipeline(name, estimator) for name, estimator in estimators.items()
         }
         self._fitted_pipeline_names = set()
         return pipelines
@@ -414,15 +409,11 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             return estimators
         if self.poniard_task == "classification":
             dummy = DummyClassifier(strategy="prior")
-            name = self._generate_estimator_name(
-                dummy, existing_names, list(estimators.values())
-            )
+            name = self._generate_estimator_name(dummy, existing_names, list(estimators.values()))
             estimators[name] = dummy
         elif self.poniard_task == "regression":
             dummy = DummyRegressor(strategy="mean")
-            name = self._generate_estimator_name(
-                dummy, existing_names, list(estimators.values())
-            )
+            name = self._generate_estimator_name(dummy, existing_names, list(estimators.values()))
             estimators[name] = dummy
         return estimators
 
@@ -464,9 +455,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             pbar.set_description(f"{name}")
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
-                warnings.filterwarnings(
-                    "ignore", message=".*will be encoded as all zeros"
-                )
+                warnings.filterwarnings("ignore", message=".*will be encoded as all zeros")
                 result = cross_validate(
                     pipeline,
                     X,
@@ -533,9 +522,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 pbar.set_description("Completed")
         return results
 
-    def predict(
-        self, X, y, estimator_names: Sequence[str] | None = None
-    ) -> dict[str, np.ndarray]:
+    def predict(self, X, y, estimator_names: Sequence[str] | None = None) -> dict[str, np.ndarray]:
         """Get cross validated target predictions where each sample belongs to a single test set.
 
         Parameters
@@ -628,9 +615,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 "datetime": datetime or [],
             }
         if self.show_info:
-            assigned_types_df = pd.DataFrame.from_dict(
-                assigned_types, orient="index"
-            ).T.fillna("")
+            assigned_types_df = pd.DataFrame.from_dict(assigned_types, orient="index").T.fillna("")
 
             if _has_ipython:
                 display(
@@ -653,7 +638,9 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     def add_preprocessing_step(
         self,
         step: (
-            Pipeline | TransformerMixin | ColumnTransformer
+            Pipeline
+            | TransformerMixin
+            | ColumnTransformer
             | tuple[str, Pipeline | TransformerMixin | ColumnTransformer]
         ),
         position: str | int = "end",
@@ -734,9 +721,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 if isinstance(item, tuple):
                     name, estimator = item
                 else:
-                    name = self._generate_estimator_name(
-                        item, existing_names, all_estimators
-                    )
+                    name = self._generate_estimator_name(item, existing_names, all_estimators)
                     estimator = item
                     existing_names.add(name)
                 new_estimators[name] = estimator
@@ -744,14 +729,14 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             self._pass_instance_attrs(new_estimator)
         self._added_estimators.update(new_estimators)
         self._removed_estimators = [
-            name
-            for name in self._removed_estimators
-            if name not in new_estimators
+            name for name in self._removed_estimators if name not in new_estimators
         ]
-        self.pipelines.update({
-            name: self._make_pipeline(name, estimator)
-            for name, estimator in new_estimators.items()
-        })
+        self.pipelines.update(
+            {
+                name: self._make_pipeline(name, estimator)
+                for name, estimator in new_estimators.items()
+            }
+        )
         return self
 
     def remove_estimators(
@@ -775,26 +760,20 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         """
         estimator_names = element_to_list_maybe(estimator_names)
         self._removed_estimators.extend(estimator_names)
-        pruned_estimators = {
-            k: v for k, v in self.pipelines.items() if k not in estimator_names
-        }
+        pruned_estimators = {k: v for k, v in self.pipelines.items() if k not in estimator_names}
         if len(pruned_estimators) == 0:
             raise ValueError("Cannot remove all estimators.")
         self.pipelines = pruned_estimators
         if drop_results:
             self._fitted_pipeline_names.difference_update(estimator_names)
             self._prediction_cache = {
-                k: v
-                for k, v in self._prediction_cache.items()
-                if k[0] not in estimator_names
+                k: v for k, v in self._prediction_cache.items() if k[0] not in estimator_names
             }
             if self._means is not None:
                 self._means = self._means.loc[~self._means.index.isin(estimator_names)]
                 self._stds = self._stds.loc[~self._stds.index.isin(estimator_names)]
                 self._cv_results = {
-                    k: v
-                    for k, v in self._cv_results.items()
-                    if k not in estimator_names
+                    k: v for k, v in self._cv_results.items() if k not in estimator_names
                 }
                 self._process_long_results()
         return self
@@ -883,9 +862,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             cv_params_for_split = {}
         else:
             cv_params_for_split = {
-                k: v
-                for k, v in vars(self.cv).items()
-                if k in ["shuffle", "random_state"]
+                k: v for k, v in vars(self.cv).items() if k in ["shuffle", "random_state"]
             }
             stratify = y if "Stratified" in self.cv.__class__.__name__ else None
             cv_params_for_split.update({"stratify": stratify})

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
-from typing import Sequence
+from collections.abc import Callable, Iterable, Sequence
+from typing import Protocol
 
 import joblib
 import numpy as np
@@ -23,11 +23,6 @@ from sklearn.pipeline import Pipeline
 from tqdm import tqdm
 
 try:
-    import polars as pl
-except ImportError:
-    pl = None
-
-try:
     from IPython.display import HTML, display
 
     _has_ipython = True
@@ -35,13 +30,45 @@ except ImportError:
     _has_ipython = False
 
 from ..preprocessing import PoniardPreprocessor
-from ..utils.estimate import element_to_list_maybe, get_target_info
+from ..utils.estimate import coerce_input, element_to_list_maybe, get_target_info
 from ..utils.utils import non_default_repr
 from .ensemble import EnsembleMixin
 from .results import ResultsMixin
 from .tuning import TuningMixin
 
-__all__ = ["PoniardBaseEstimator"]
+__all__ = ["PoniardBaseEstimator", "EstimatorView"]
+
+
+class EstimatorView(Protocol):
+    """Internal estimator surface used by plotting and error analysis.
+
+    Satellite modules (`PoniardPlotFactory`, `ErrorAnalyzer`) interact with a
+    Poniard estimator only through the members declared here. These are
+    private-by-convention but form a stable contract between the core estimator
+    and its satellites; reaching past this surface into implementation detail
+    is a defect.
+    """
+
+    poniard_task: str
+    pipelines: dict
+    feature_types: dict
+    target_info: dict
+    random_state: int
+    n_jobs: int | None
+    verbose: bool
+    cv: object
+    _means: pd.DataFrame | None
+    _stds: pd.DataFrame | None
+    _long_results: pd.DataFrame | None
+    _cv_results: dict
+
+    def get_results(self, *args, **kwargs) -> pd.DataFrame: ...
+    def pareto(self, *args, **kwargs) -> pd.DataFrame: ...
+    def get_predictions_similarity(self, X, y, on_errors: bool = True) -> pd.DataFrame: ...
+    def _first_scorer(self, sklearn_scorer: bool) -> str | Callable: ...
+    def _dummy_names(self) -> list[str]: ...
+    def _train_test_split_from_cv(self, X, y): ...
+    def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str) -> np.ndarray: ...
 
 
 class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
@@ -91,7 +118,16 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         n_jobs: int | None = None,
     ):
 
-        self._init_params = {k: v for k, v in locals().items() if k != "self"}
+        self._init_params = {
+            "estimators": estimators,
+            "metrics": metrics,
+            "preprocess": preprocess,
+            "custom_preprocessor": custom_preprocessor,
+            "cv": cv,
+            "verbose": verbose,
+            "random_state": random_state,
+            "n_jobs": n_jobs,
+        }
         if metrics and (
             (isinstance(metrics, Sequence) and not all(isinstance(m, str) for m in metrics))
             or (
@@ -186,14 +222,8 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         tuple
             The converted `X` and `y`, which `fit` uses for cross-validation.
         """
-        if pl is not None and isinstance(X, (pl.DataFrame, pl.Series)):
-            X = X.to_pandas()
-        if pl is not None and isinstance(y, (pl.DataFrame, pl.Series)):
-            y = y.to_pandas()
-        if not isinstance(X, (pd.DataFrame, pd.Series, np.ndarray)):
-            X = np.array(X)
-        if not isinstance(y, (pd.DataFrame, pd.Series, np.ndarray)):
-            y = np.array(y)
+        X = coerce_input(X)
+        y = coerce_input(y)
         self.show_info = show_info
         self.target_info = get_target_info(y, self.poniard_task)
         if self.target_info["type_"] == "multiclass-multioutput":
@@ -210,7 +240,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             if self.custom_preprocessor and not isinstance(
                 self.custom_preprocessor, PoniardPreprocessor
             ):
-                self.preprocessor = self.custom_preprocessor
+                self.preprocessor = clone(self.custom_preprocessor)
             else:
                 self.preprocessor = self._build_preprocessor(X, y)
             self._pass_instance_attrs(self.preprocessor)
@@ -315,11 +345,14 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     def _make_pipeline(self, name: str, estimator) -> Pipeline:
         """Create a Pipeline for an estimator, optionally including the preprocessor.
 
-        The wrapping pipeline is configured to output pandas DataFrames on
-        ``transform``. This propagates to any preprocessor step (including a
-        user-supplied custom one) so downstream code keeps the pandas contract
+        The estimator is cloned and configured (random_state, verbose) so the
+        user's original object is never mutated. The wrapping pipeline is
+        configured to output pandas DataFrames on ``transform``, propagating to
+        any preprocessor step so downstream code keeps the pandas contract
         without relying on a global sklearn config.
         """
+        estimator = clone(estimator)
+        self._pass_instance_attrs(estimator)
         if self.preprocess:
             pipe = Pipeline(
                 [("preprocessor", self.preprocessor), (name, estimator)],
@@ -348,7 +381,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 pass
 
     @staticmethod
-    def _generate_estimator_name(estimator, existing_names: set[str], all_estimators: list) -> str:
+    def _generate_estimator_name(estimator, existing_names: set[str]) -> str:
         """Generate a name for an estimator.
 
         Default is the class name. If it clashes, append _2, _3, etc.
@@ -381,25 +414,18 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 if isinstance(item, tuple):
                     name, estimator = item
                 else:
-                    name = self._generate_estimator_name(
-                        item, set(estimators.keys()), self.estimators
-                    )
+                    name = self._generate_estimator_name(item, set(estimators.keys()))
                     estimator = item
                 estimators[name] = estimator
         else:
             estimators = {}
             for estimator in self._default_estimators:
-                name = self._generate_estimator_name(
-                    estimator, set(estimators.keys()), self._default_estimators
-                )
+                name = self._generate_estimator_name(estimator, set(estimators.keys()))
                 estimators[name] = estimator
         estimators.update(self._added_estimators)
         for name in self._removed_estimators:
             estimators.pop(name, None)
         estimators = self._add_dummy_estimators(estimators)
-
-        for estimator in estimators.values():
-            self._pass_instance_attrs(estimator)
 
         pipelines = {
             name: self._make_pipeline(name, estimator) for name, estimator in estimators.items()
@@ -413,11 +439,11 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             return estimators
         if self.poniard_task == "classification":
             dummy = DummyClassifier(strategy="prior")
-            name = self._generate_estimator_name(dummy, existing_names, list(estimators.values()))
+            name = self._generate_estimator_name(dummy, existing_names)
             estimators[name] = dummy
         elif self.poniard_task == "regression":
             dummy = DummyRegressor(strategy="mean")
-            name = self._generate_estimator_name(dummy, existing_names, list(estimators.values()))
+            name = self._generate_estimator_name(dummy, existing_names)
             estimators[name] = dummy
         return estimators
 
@@ -508,7 +534,14 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         for i, name in enumerate(pbar):
             pbar.set_description(f"{name}")
             pipeline = self.pipelines[name]
-            try:
+            if not hasattr(pipeline, method):
+                warnings.warn(
+                    f"{name} does not support `{method}` method. Filling with nan.",
+                    stacklevel=2,
+                )
+                result = np.empty(y.shape)
+                result[:] = np.nan
+            else:
                 result = cross_val_predict(
                     pipeline,
                     X,
@@ -518,13 +551,6 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                     verbose=self.verbose,
                     n_jobs=self.n_jobs,
                 )
-            except AttributeError:
-                warnings.warn(
-                    f"{name} does not support `{method}` method. Filling with nan.",
-                    stacklevel=2,
-                )
-                result = np.empty(y.shape)
-                result[:] = np.nan
             results.update({name: result})
             self._prediction_cache[(name, method)] = result
 
@@ -685,7 +711,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             elif position == "end":
                 position = len(existing_preprocessor.steps)
         if isinstance(existing_preprocessor, Pipeline):
-            existing_preprocessor.steps.insert(position, step)
+            # Work on a clone so a user-supplied custom preprocessor is never
+            # mutated in place; pipelines are rebuilt below with the result.
+            self.preprocessor = clone(existing_preprocessor)
+            self.preprocessor.steps.insert(position, step)
         else:
             if isinstance(position, int):
                 raise ValueError(
@@ -729,17 +758,14 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         else:
             new_estimators = {}
             existing_names = set(self.pipelines.keys())
-            all_estimators = list(estimators)
             for item in estimators:
                 if isinstance(item, tuple):
                     name, estimator = item
                 else:
-                    name = self._generate_estimator_name(item, existing_names, all_estimators)
+                    name = self._generate_estimator_name(item, existing_names)
                     estimator = item
                     existing_names.add(name)
                 new_estimators[name] = estimator
-        for new_estimator in new_estimators.values():
-            self._pass_instance_attrs(new_estimator)
         self._added_estimators.update(new_estimators)
         self._removed_estimators = [
             name for name in self._removed_estimators if name not in new_estimators

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -222,6 +222,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         self.pipelines = self._build_pipelines()
         self.cv = self._build_cv()
 
+        # Predictions are only valid for the data this estimator was configured
+        # with; reconfiguring with (possibly new) data invalidates them.
+        self._prediction_cache.clear()
+
         return X, y
 
     def _print_setup_info(self):
@@ -487,14 +491,20 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         self, method: str, X, y, estimator_names: Sequence[str] | None = None
     ) -> dict[str, np.ndarray]:
         """Helper method for predicting targets or target probabilities with cross validation.
-        Accepts predict, predict_proba, predict_log_proba or decision_function."""
+        Accepts predict, predict_proba, predict_log_proba or decision_function.
+
+        Results are cached by ``(estimator_name, method)`` and reused across
+        calls within a configured session, so plots, error analysis and repeat
+        calls do not rerun cross-validation.
+        """
         if not self.pipelines:
             raise ValueError("`setup` must be called before `predict`.")
         estimator_names = element_to_list_maybe(estimator_names)
         if not estimator_names:
             estimator_names = [estimator for estimator in self.pipelines.keys()]
+        missing = [name for name in estimator_names if (name, method) not in self._prediction_cache]
         results = {}
-        pbar = tqdm(estimator_names, leave=self._tqdm_leave)
+        pbar = tqdm(missing, leave=self._tqdm_leave)
         for i, name in enumerate(pbar):
             pbar.set_description(f"{name}")
             pipeline = self.pipelines[name]
@@ -520,6 +530,9 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
+        for name in estimator_names:
+            if name not in results:
+                results[name] = self._prediction_cache[(name, method)]
         return results
 
     def predict(self, X, y, estimator_names: Sequence[str] | None = None) -> dict[str, np.ndarray]:

--- a/poniard/estimators/ensemble.py
+++ b/poniard/estimators/ensemble.py
@@ -77,10 +77,7 @@ class EnsembleMixin:
             raise ValueError("Strategy must be either 'diversity' or 'top_n'.")
         estimator_names = element_to_list_maybe(estimator_names)
         if estimator_names:
-            models = [
-                (name, self.pipelines[name]._final_estimator)
-                for name in estimator_names
-            ]
+            models = [(name, self.pipelines[name]._final_estimator) for name in estimator_names]
         elif strategy == "diversity" and X is not None and y is not None:
             selected = self._select_diverse(
                 top_n=top_n or 3,
@@ -89,9 +86,7 @@ class EnsembleMixin:
                 X=X,
                 y=y,
             )
-            models = [
-                (name, self.pipelines[name]._final_estimator) for name in selected
-            ]
+            models = [(name, self.pipelines[name]._final_estimator) for name in selected]
         else:
             if sort_by:
                 sorter = sort_by
@@ -103,19 +98,12 @@ class EnsembleMixin:
                 for name in self._means.sort_values(sorter, ascending=False).index
                 if name not in dummy
             ]
-            models = [
-                (name, self.pipelines[name]._final_estimator)
-                for name in eligible[:top_n]
-            ]
+            models = [(name, self.pipelines[name]._final_estimator) for name in eligible[:top_n]]
         if method == "voting":
             if self.poniard_task == "classification":
-                ensemble = VotingClassifier(
-                    estimators=models, verbose=self.verbose, **kwargs
-                )
+                ensemble = VotingClassifier(estimators=models, verbose=self.verbose, **kwargs)
             else:
-                ensemble = VotingRegressor(
-                    estimators=models, verbose=self.verbose, **kwargs
-                )
+                ensemble = VotingRegressor(estimators=models, verbose=self.verbose, **kwargs)
         else:
             if self.poniard_task == "classification":
                 ensemble = StackingClassifier(
@@ -180,11 +168,7 @@ class EnsembleMixin:
                 break
             if name not in sim_matrix.index:
                 continue
-            max_sim = max(
-                abs(sim_matrix.loc[name, s])
-                for s in selected
-                if s in sim_matrix.columns
-            )
+            max_sim = max(abs(sim_matrix.loc[name, s]) for s in selected if s in sim_matrix.columns)
             if np.isnan(max_sim) or max_sim <= similarity_threshold:
                 selected.append(name)
 

--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -78,6 +78,11 @@ class PoniardRegressor(PoniardBaseEstimator):
         )
 
     @property
+    def poniard_task(self) -> str:
+        """Return the task name."""
+        return "regression"
+
+    @property
     def _default_estimators(self) -> list[RegressorMixin]:
         return [
             LinearRegression(),

--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ['PoniardRegressor']
+__all__ = ["PoniardRegressor"]
 
 from collections.abc import Callable
 from typing import Sequence
@@ -87,17 +87,13 @@ class PoniardRegressor(PoniardBaseEstimator):
         return [
             LinearRegression(),
             ElasticNet(random_state=self.random_state),
-            LinearSVR(
-                verbose=self.verbose, random_state=self.random_state, max_iter=5000
-            ),
+            LinearSVR(verbose=self.verbose, random_state=self.random_state, max_iter=5000),
             KNeighborsRegressor(),
             DecisionTreeRegressor(random_state=self.random_state),
             RandomForestRegressor(
                 random_state=self.random_state, verbose=self.verbose, n_jobs=self.n_jobs
             ),
-            HistGradientBoostingRegressor(
-                random_state=self.random_state, verbose=self.verbose
-            ),
+            HistGradientBoostingRegressor(random_state=self.random_state, verbose=self.verbose),
         ]
 
     def _build_metrics(self) -> dict[str, Callable] | list[str]:

--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 __all__ = ["PoniardRegressor"]
 
-from collections.abc import Callable
-from typing import Sequence
+from collections.abc import Callable, Sequence
 
-from sklearn.base import RegressorMixin, TransformerMixin
+from sklearn.base import RegressorMixin, TransformerMixin, clone
 from sklearn.ensemble import (
     HistGradientBoostingRegressor,
     RandomForestRegressor,
@@ -109,5 +108,7 @@ class PoniardRegressor(PoniardBaseEstimator):
         if isinstance(cv, int):
             return KFold(n_splits=cv, shuffle=True, random_state=self.random_state)
         else:
+            if isinstance(cv, (BaseCrossValidator, BaseShuffleSplit)):
+                cv = clone(cv, safe=False)
             self._pass_instance_attrs(cv)
             return cv

--- a/poniard/estimators/results.py
+++ b/poniard/estimators/results.py
@@ -43,9 +43,7 @@ class ResultsMixin:
         means = self._means
         stds = self._stds
         if not return_train_scores:
-            means = means.loc[
-                :, means.columns.str.contains("test_|fit|score", regex=True)
-            ]
+            means = means.loc[:, means.columns.str.contains("test_|fit|score", regex=True)]
             stds = stds.loc[:, stds.columns.str.contains("test_|fit|score", regex=True)]
         if wrt_dummy:
             dummy_names = self._dummy_names()
@@ -130,25 +128,25 @@ class ResultsMixin:
                     _, p = sp_stats.ttest_rel(sa, sb)
                 else:
                     p = np.nan
-                all_pairs.append({
-                    "metric": metric,
-                    "estimator_a": a,
-                    "estimator_b": b,
-                    "mean_diff": float(np.mean(diff)),
-                    "wins_a": wins_a,
-                    "wins_b": wins_b,
-                    "ties": ties,
-                    "p_value": float(p) if not np.isnan(p) else np.nan,
-                })
+                all_pairs.append(
+                    {
+                        "metric": metric,
+                        "estimator_a": a,
+                        "estimator_b": b,
+                        "mean_diff": float(np.mean(diff)),
+                        "wins_a": wins_a,
+                        "wins_b": wins_b,
+                        "ties": ties,
+                        "p_value": float(p) if not np.isnan(p) else np.nan,
+                    }
+                )
         if not all_pairs:
             return pd.DataFrame()
         df = pd.DataFrame(all_pairs)
         df = df.set_index(["metric", "estimator_a", "estimator_b"])
         return df
 
-    def pareto(
-        self, metric: str | None = None, time_col: str = "fit_time"
-    ) -> pd.DataFrame:
+    def pareto(self, metric: str | None = None, time_col: str = "fit_time") -> pd.DataFrame:
         """Return the Pareto-optimal set of estimators (best metric vs lowest time).
 
         An estimator is Pareto-optimal if no other estimator is both faster
@@ -313,9 +311,7 @@ class ResultsMixin:
             else:
                 return list(self.metrics.keys())[0]
         else:
-            raise ValueError(
-                "self.metrics can only be a sequence of str or dict of str: callable."
-            )
+            raise ValueError("self.metrics can only be a sequence of str or dict of str: callable.")
 
     def get_predictions_similarity(
         self,
@@ -359,12 +355,8 @@ class ResultsMixin:
         dummy_names = self._dummy_names()
         if self.poniard_task == "classification":
             estimator_names = [x for x in results.columns if x not in dummy_names]
-            table = pd.DataFrame(
-                data=np.nan, index=estimator_names, columns=estimator_names
-            )
-            for row, col in itertools.combinations_with_replacement(
-                table.index[::-1], 2
-            ):
+            table = pd.DataFrame(data=np.nan, index=estimator_names, columns=estimator_names)
+            for row, col in itertools.combinations_with_replacement(table.index[::-1], 2):
                 cramer = cramers_v(results[row], results[col])
                 if row == col:
                     table.loc[row, col] = 1

--- a/poniard/estimators/results.py
+++ b/poniard/estimators/results.py
@@ -114,7 +114,7 @@ class ResultsMixin:
         for metric in metric_cols:
             fold_data = {}
             for name in names:
-                raw = self._experiment_results[name].get(metric)
+                raw = self._cv_results[name].get(metric)
                 if raw is None:
                     continue
                 fold_data[name] = np.array(raw)
@@ -261,15 +261,7 @@ class ResultsMixin:
         Also computes per-sample fit and score times when fold sizes are
         available (set by ``PoniardBaseEstimator.fit``).
         """
-        results = pd.DataFrame(self._experiment_results).T
-        results = results.loc[
-            :,
-            [
-                x
-                for x in results.columns
-                if x not in ["predict", "predict_proba", "decision_function"]
-            ],
-        ]
+        results = pd.DataFrame(self._cv_results).T
         means = results.apply(lambda x: np.mean(np.stack(x.values), axis=1))
         stds = results.apply(lambda x: np.std(np.stack(x.values), axis=1))
         time_columns = ["fit_time", "score_time"]
@@ -278,13 +270,13 @@ class ResultsMixin:
         stds = stds[metric_columns + time_columns]
 
         # Per-sample times: divide fold times by test fold sizes
-        fold_sizes = getattr(self, "_fold_sizes", None)
+        fold_sizes = self._fold_sizes
         if fold_sizes is not None:
             sizes = np.array(fold_sizes, dtype=float)
             per_sample_cols = {}
             for estimator_name in means.index:
-                raw_fit = np.array(self._experiment_results[estimator_name].get("fit_time", []))
-                raw_score = np.array(self._experiment_results[estimator_name].get("score_time", []))
+                raw_fit = np.array(self._cv_results[estimator_name].get("fit_time", []))
+                raw_score = np.array(self._cv_results[estimator_name].get("score_time", []))
                 fit_ps = np.mean(raw_fit / sizes) if len(raw_fit) == len(sizes) else np.nan
                 score_ps = np.mean(raw_score / sizes) if len(raw_score) == len(sizes) else np.nan
                 per_sample_cols.setdefault("fit_time_per_sample", []).append(fit_ps)
@@ -298,7 +290,7 @@ class ResultsMixin:
 
     def _process_long_results(self) -> None:
         """Prepare experiment results for plotting."""
-        base = pd.DataFrame(self._experiment_results).T
+        base = pd.DataFrame(self._cv_results).T
         melted = (
             base.rename_axis("Model")
             .reset_index()

--- a/poniard/estimators/tuning.py
+++ b/poniard/estimators/tuning.py
@@ -117,8 +117,6 @@ class TuningMixin:
         best_final = clone(search.best_estimator_._final_estimator)
         self.add_estimators(estimators={tuned_estimator_name: best_final})
 
-        if not hasattr(self, "_tuning_results"):
-            self._tuning_results = {}
         self._tuning_results[tuned_estimator_name] = {
             "baseline": estimator_name,
             "mode": mode,
@@ -163,7 +161,7 @@ class TuningMixin:
             ``best_score_``, ``scorer``, and the fitted sklearn ``search``
             object (full escape hatch: ``cv_results_``, etc.).
         """
-        results = getattr(self, "_tuning_results", None)
+        results = self._tuning_results
         if not results:
             raise ValueError(
                 "No tuning results. Call tune_estimator(...) first."

--- a/poniard/estimators/tuning.py
+++ b/poniard/estimators/tuning.py
@@ -62,8 +62,7 @@ class TuningMixin:
         """
         if estimator_name not in self.pipelines:
             raise KeyError(
-                f"Unknown estimator {estimator_name!r}. "
-                f"Available: {list(self.pipelines)}"
+                f"Unknown estimator {estimator_name!r}. Available: {list(self.pipelines)}"
             )
         if not grid:
             raise ValueError(
@@ -163,14 +162,11 @@ class TuningMixin:
         """
         results = self._tuning_results
         if not results:
-            raise ValueError(
-                "No tuning results. Call tune_estimator(...) first."
-            )
+            raise ValueError("No tuning results. Call tune_estimator(...) first.")
         if estimator_name is not None:
             if estimator_name not in results:
                 raise KeyError(
-                    f"No tuning results for {estimator_name!r}. "
-                    f"Available: {list(results)}"
+                    f"No tuning results for {estimator_name!r}. Available: {list(results)}"
                 )
             return results[estimator_name]
         if len(results) == 1:

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -22,9 +22,7 @@ try:
     from plotly.graph_objs._figure import Figure
     from plotly.subplots import make_subplots
 except ImportError as e:
-    raise ImportError(
-        "plotly is required for plotting. Install it with: pip install plotly"
-    ) from e
+    raise ImportError("plotly is required for plotting. Install it with: pip install plotly") from e
 
 
 class PoniardPlotFactory:
@@ -58,9 +56,7 @@ class PoniardPlotFactory:
         self._estimator = estimator
 
         self._template = plot_config.get("template", "plotly_white")
-        self._discrete_colors = plot_config.get(
-            "discrete_colors", px.colors.qualitative.Bold
-        )
+        self._discrete_colors = plot_config.get("discrete_colors", px.colors.qualitative.Bold)
         self._font_family = plot_config.get("font_family", "Helvetica")
         self._font_color = plot_config.get("font_color", "#8C8C8C")
 
@@ -164,9 +160,7 @@ class PoniardPlotFactory:
         else:
             stds = self._estimator._stds.reset_index().melt(id_vars="index")
             stds.columns = ["Model", "Metric", "Score"]
-            stds["Model"] = stds["Model"].str.replace(
-                "Classifier|Regressor", "", regex=True
-            )
+            stds["Model"] = stds["Model"].str.replace("Classifier|Regressor", "", regex=True)
             results = results.loc[results["Type"] == "Mean"].merge(
                 stds, how="left", on=["Model", "Metric"], suffixes=(None, "_y")
             )
@@ -191,9 +185,7 @@ class PoniardPlotFactory:
 
         return fig
 
-    def overfitness(
-        self, metric: str | None = None, exclude_dummy: bool = True
-    ) -> Figure:
+    def overfitness(self, metric: str | None = None, exclude_dummy: bool = True) -> Figure:
         """Plot the ratio of test scores to train scores for every estimator.
 
         Parameters
@@ -290,14 +282,10 @@ class PoniardPlotFactory:
         importances.rename_axis("Feature", inplace=True)
         importances.reset_index(inplace=True)
 
-        importances = importances.melt(
-            id_vars="Feature", var_name="Type", value_name="Importance"
-        )
+        importances = importances.melt(id_vars="Feature", var_name="Type", value_name="Importance")
         importances["Type"] = "Repetition"
         aggs = (
-            importances.groupby("Feature")["Importance"]
-            .agg(Mean="mean", Std="std")
-            .reset_index()
+            importances.groupby("Feature")["Importance"].agg(Mean="mean", Std="std").reset_index()
         )
         aggs = aggs.melt(id_vars="Feature", var_name="Type", value_name="Importance")
         importances = pd.concat([importances, aggs])
@@ -314,9 +302,7 @@ class PoniardPlotFactory:
                 **self._px_kwargs(),
             )
         else:
-            importances = importances.loc[
-                -importances["Type"].isin(["Repetition", "Std"])
-            ]
+            importances = importances.loc[-importances["Type"].isin(["Repetition", "Std"])]
             fig = px.bar(
                 importances,
                 x="Importance",
@@ -476,9 +462,7 @@ class PoniardPlotFactory:
         self._apply_layout(fig)
         return fig
 
-    def partial_dependence(
-        self, estimator_name: str, feature: str | int, **kwargs
-    ) -> Figure:
+    def partial_dependence(self, estimator_name: str, feature: str | int, **kwargs) -> Figure:
         """Plot partial dependence for a single feature of a single estimator.
 
         In essence, visualize how the target changes within the feature's range.
@@ -503,9 +487,7 @@ class PoniardPlotFactory:
         X = self._X
         estimator = clone(self._estimator.pipelines[estimator_name])
         estimator.fit(X, y)
-        partial_dep = partial_dependence(
-            estimator, X, features=[feature], kind="average", **kwargs
-        )
+        partial_dep = partial_dependence(estimator, X, features=[feature], kind="average", **kwargs)
         response = partial_dep["average"].reshape(-1)
         grid_values = partial_dep.get("grid_values", partial_dep.get("values"))
         n_values = len(grid_values[0])
@@ -540,9 +522,7 @@ class PoniardPlotFactory:
         estimator_names = element_to_list_maybe(estimator_names)
         data = []
         for name in estimator_names:
-            y_pred = self._estimator._get_or_compute_prediction(
-                self._X, self._y, name, "predict"
-            )
+            y_pred = self._estimator._get_or_compute_prediction(self._X, self._y, name, "predict")
             if y.ndim == 1:
                 y_2d = np.expand_dims(y, 1)
             else:
@@ -599,9 +579,7 @@ class PoniardPlotFactory:
             Residuals histogram plot.
         """
         if self._estimator.poniard_task == "classification":
-            raise ValueError(
-                "Residuals histogram plot is not available for classifiers."
-            )
+            raise ValueError("Residuals histogram plot is not available for classifiers.")
         data = self._build_residuals_data(estimator_names)
         fig = px.histogram(
             data,
@@ -644,33 +622,23 @@ class PoniardPlotFactory:
         sorted_means = self._estimator._long_results.query(
             f"Metric == 'test_{main_scorer}' & Type=='Mean'"
         ).sort_values(ascending=False, by="Score")
-        estimator_position = sorted_means.set_index("Model").index.get_loc(
-            estimator_name
-        )
+        estimator_position = sorted_means.set_index("Model").index.get_loc(estimator_name)
         if estimator_position == 0:
             better_estimator_name = None
             worse_estimator_name = sorted_means.iloc[1, 0]
         elif estimator_position == len(self._estimator.pipelines) - 1:
-            better_estimator_name = sorted_means.iloc[
-                len(self._estimator.pipelines) - 2, 0
-            ]
+            better_estimator_name = sorted_means.iloc[len(self._estimator.pipelines) - 2, 0]
             worse_estimator_name = None
         else:
             better_estimator_name = sorted_means.iloc[estimator_position - 1, 0]
             worse_estimator_name = sorted_means.iloc[estimator_position + 1, 0]
         estimator_names = [
-            x
-            for x in [estimator_name, better_estimator_name, worse_estimator_name]
-            if x
+            x for x in [estimator_name, better_estimator_name, worse_estimator_name] if x
         ]
 
         metrics = self._estimator.get_results()
-        metric_rankings = metrics.loc[:, ~metrics.columns.str.contains("time")].rank(
-            ascending=True
-        )
-        time_rankings = metrics.loc[:, metrics.columns.str.contains("time")].rank(
-            ascending=False
-        )
+        metric_rankings = metrics.loc[:, ~metrics.columns.str.contains("time")].rank(ascending=True)
+        time_rankings = metrics.loc[:, metrics.columns.str.contains("time")].rank(ascending=False)
         rankings = pd.concat([metric_rankings, time_rankings], axis=1)
         rank = px.bar(
             rankings.loc[estimator_name, :],

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -357,7 +357,7 @@ class PoniardPlotFactory:
         y = self._y
         if y.ndim > 1:
             raise ValueError("ROC curve is only available for binary classification.")
-        results = self._estimator._experiment_results
+        results = self._estimator._cv_results
         estimator_names = element_to_list_maybe(estimator_names)
         if not estimator_names:
             estimator_names = list(results.keys())

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -13,7 +13,7 @@ from sklearn.inspection import partial_dependence, permutation_importance
 from sklearn.metrics import auc, confusion_matrix, roc_curve
 
 if TYPE_CHECKING:
-    from poniard.estimators.core import PoniardBaseEstimator
+    from poniard.estimators.core import EstimatorView
 from ..utils.estimate import element_to_list_maybe
 
 try:
@@ -48,12 +48,12 @@ class PoniardPlotFactory:
         self,
         X,
         y,
-        estimator: PoniardBaseEstimator,
+        estimator: EstimatorView,
         **plot_config,
     ):
         self._X = X
         self._y = y
-        self._estimator = estimator
+        self._estimator: EstimatorView = estimator
 
         self._template = plot_config.get("template", "plotly_white")
         self._discrete_colors = plot_config.get("discrete_colors", px.colors.qualitative.Bold)
@@ -342,6 +342,8 @@ class PoniardPlotFactory:
             raise ValueError("ROC curve is not available for regressors.")
         y = self._y
         if y.ndim > 1:
+            raise ValueError("ROC curve is only available for binary classification.")
+        if len(np.unique(y)) != 2:
             raise ValueError("ROC curve is only available for binary classification.")
         results = self._estimator._cv_results
         estimator_names = element_to_list_maybe(estimator_names)
@@ -716,7 +718,6 @@ class PoniardPlotFactory:
     def error_lift_bars(
         self,
         lift_by_target: pd.DataFrame | None = None,
-        estimator_names: str | Sequence[str] | None = None,
         top_n: int | None = None,
     ) -> Figure:
         """Bar chart of error lift by target class or bin.
@@ -727,12 +728,8 @@ class PoniardPlotFactory:
         Parameters
         ----------
         lift_by_target :
-            From ``ErrorReport.lift_by_target``. If None, computes it from
-            the estimator's last ``ErrorAnalyzer.analyze()`` call (requires
-            ``ErrorAnalyzer`` to have been run).
-        estimator_names :
-            Not used for this plot (lift is cross-estimator). Kept for
-            API consistency.
+            From ``ErrorReport.lift_by_target``. Required: pass
+            ``ErrorAnalyzer.from_poniard(clf).analyze(X, y).lift_by_target``.
         top_n :
             Show only the top N classes/bins by lift. Default None (all).
 
@@ -835,8 +832,6 @@ class PoniardPlotFactory:
         Figure
             Plotly scatter plot.
         """
-        from sklearn.dummy import DummyClassifier, DummyRegressor
-
         results = self._estimator.get_results()
         if metric is None:
             metric = results.columns[0]
@@ -848,10 +843,7 @@ class PoniardPlotFactory:
         pareto = self._estimator.pareto(metric=metric, time_col=time_col)
         pareto_names = set(pareto.index)
 
-        dummy = set()
-        for name, pipeline in self._estimator.pipelines.items():
-            if isinstance(pipeline._final_estimator, (DummyClassifier, DummyRegressor)):
-                dummy.add(name)
+        dummy = set(self._estimator._dummy_names())
 
         df = results[[metric, time_col]].copy()
         df["type"] = "model"

--- a/poniard/preprocessing/__init__.py
+++ b/poniard/preprocessing/__init__.py
@@ -1,4 +1,4 @@
-from poniard.preprocessing.core import PoniardPreprocessor
+from poniard.preprocessing.core import PoniardPreprocessor, infer_feature_types
 from poniard.preprocessing.datetime import DatetimeEncoder
 
-__all__ = ["PoniardPreprocessor", "DatetimeEncoder"]
+__all__ = ["PoniardPreprocessor", "DatetimeEncoder", "infer_feature_types"]

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import tempfile
 import warnings
-from typing import TYPE_CHECKING
 
 import joblib
 import numpy as np
@@ -23,19 +22,104 @@ from sklearn.preprocessing import (
     TargetEncoder,
 )
 
-try:
-    import polars as pl
-except ImportError:
-    pl = None
-
-from ..utils.estimate import get_target_info
+from ..utils.estimate import coerce_input, get_target_info
 from ..utils.utils import non_default_repr
 from .datetime import DatetimeEncoder
 
-if TYPE_CHECKING:
-    pass
+__all__ = ["PoniardPreprocessor", "infer_feature_types"]
 
-__all__ = ["PoniardPreprocessor"]
+
+def infer_feature_types(
+    X: pd.DataFrame | np.ndarray,
+    numeric_threshold: int | float,
+    cardinality_threshold: int | float,
+) -> dict[str, list]:
+    """Infer feature types from the data.
+
+    Features are classified as numeric, low-cardinality categorical,
+    high-cardinality categorical or datetime. Float thresholds are
+    interpreted as a fraction of the number of rows.
+
+    Parameters
+    ----------
+    X :
+        Features (pandas DataFrame or numpy array).
+    numeric_threshold :
+        Number of unique values above which a number-like feature is treated
+        as numeric. If float, `numeric_threshold * n_samples`.
+    cardinality_threshold :
+        Non-number features with more unique values than this are treated as
+        high-cardinality (ordinal/target encoded). If float, it is
+        `cardinality_threshold * n_samples`.
+
+    Returns
+    -------
+    dict[str, list]
+        Keys ``numeric``, ``categorical_high``, ``categorical_low``,
+        ``datetime``; values are column names (DataFrame input) or indices
+        (array input).
+    """
+    numeric: list = []
+    categorical_high: list = []
+    categorical_low: list = []
+    datetime_cols: list = []
+
+    cardinality_threshold = (
+        cardinality_threshold
+        if isinstance(cardinality_threshold, int)
+        else int(cardinality_threshold * X.shape[0])
+    )
+    numeric_threshold = (
+        numeric_threshold
+        if isinstance(numeric_threshold, int)
+        else int(numeric_threshold * X.shape[0])
+    )
+
+    if isinstance(X, pd.DataFrame):
+        for col in X.columns:
+            dtype = X[col].dtype
+            nunique = X[col].nunique()
+
+            if pd.api.types.is_datetime64_any_dtype(dtype):
+                datetime_cols.append(col)
+            elif pd.api.types.is_numeric_dtype(dtype):
+                if nunique > numeric_threshold:
+                    numeric.append(col)
+                elif nunique > cardinality_threshold:
+                    categorical_high.append(col)
+                else:
+                    categorical_low.append(col)
+            else:
+                # strings, objects, categorical, boolean
+                if nunique > cardinality_threshold:
+                    categorical_high.append(col)
+                else:
+                    categorical_low.append(col)
+    else:
+        for i in range(X.shape[1]):
+            col = X[:, i]
+            nunique = len(np.unique(col))
+            if np.issubdtype(col.dtype, np.datetime64):
+                datetime_cols.append(i)
+            elif np.issubdtype(col.dtype, np.number):
+                if nunique > numeric_threshold:
+                    numeric.append(i)
+                elif nunique > cardinality_threshold:
+                    categorical_high.append(i)
+                else:
+                    categorical_low.append(i)
+            else:
+                if nunique > cardinality_threshold:
+                    categorical_high.append(i)
+                else:
+                    categorical_low.append(i)
+
+    return {
+        "numeric": numeric,
+        "categorical_high": categorical_high,
+        "categorical_low": categorical_low,
+        "datetime": datetime_cols,
+    }
 
 
 class PoniardPreprocessor:
@@ -90,7 +174,20 @@ class PoniardPreprocessor:
         cache_transformations: bool = False,
         cache_dir: str | os.PathLike | None = None,
     ):
-        self._init_params = {k: v for k, v in locals().items() if k != "self"}
+        self._init_params = {
+            "task": task,
+            "scaler": scaler,
+            "high_cardinality_encoder": high_cardinality_encoder,
+            "numeric_imputer": numeric_imputer,
+            "custom_preprocessor": custom_preprocessor,
+            "numeric_threshold": numeric_threshold,
+            "cardinality_threshold": cardinality_threshold,
+            "verbose": verbose,
+            "random_state": random_state,
+            "n_jobs": n_jobs,
+            "cache_transformations": cache_transformations,
+            "cache_dir": cache_dir,
+        }
         self.task = task
         self.scaler = scaler or "standard"
         self.high_cardinality_encoder = high_cardinality_encoder or "target"
@@ -235,16 +332,8 @@ class PoniardPreprocessor:
         y: pd.DataFrame | np.ndarray | list | None = None,
     ) -> PoniardPreprocessor:
         if X is not None and y is not None:
-            if pl is not None and isinstance(X, (pl.DataFrame, pl.Series)):
-                X = X.to_pandas()
-            if pl is not None and isinstance(y, (pl.DataFrame, pl.Series)):
-                y = y.to_pandas()
-            if not isinstance(X, (pd.DataFrame, pd.Series, np.ndarray)):
-                X = np.array(X)
-            if not isinstance(y, (pd.DataFrame, pd.Series, np.ndarray)):
-                y = np.array(y)
-            self.X = X
-            self.y = y
+            self.X = coerce_input(X)
+            self.y = coerce_input(y)
         elif not hasattr(self, "X") or not hasattr(self, "y"):
             raise NotImplementedError("Both X and y need to be passed to _setup_data.")
         return self
@@ -328,80 +417,25 @@ class PoniardPreprocessor:
         )
 
     def _infer_dtypes(self) -> tuple[list, list, list, list]:
-        """Infer feature types (numeric, low-cardinality categorical,
-        high-cardinality categorical, datetime).
+        """Infer feature types for ``self.X`` and store them.
 
         Returns
         -------
         tuple[list, list, list, list]
             Four lists with column names or indices.
         """
-        X = self.X
-        numeric: list = []
-        categorical_high: list = []
-        categorical_low: list = []
-        datetime_cols: list = []
-
-        cardinality_threshold = (
-            self.cardinality_threshold
-            if isinstance(self.cardinality_threshold, int)
-            else int(self.cardinality_threshold * X.shape[0])
+        self.feature_types = infer_feature_types(
+            self.X, self.numeric_threshold, self.cardinality_threshold
         )
-        numeric_threshold = (
-            self.numeric_threshold
-            if isinstance(self.numeric_threshold, int)
-            else int(self.numeric_threshold * X.shape[0])
-        )
-
-        if isinstance(X, pd.DataFrame):
-            for col in X.columns:
-                dtype = X[col].dtype
-                nunique = X[col].nunique()
-
-                if pd.api.types.is_datetime64_any_dtype(dtype):
-                    datetime_cols.append(col)
-                elif pd.api.types.is_numeric_dtype(dtype):
-                    if nunique > numeric_threshold:
-                        numeric.append(col)
-                    elif nunique > cardinality_threshold:
-                        categorical_high.append(col)
-                    else:
-                        categorical_low.append(col)
-                else:
-                    # strings, objects, categorical, boolean
-                    if nunique > cardinality_threshold:
-                        categorical_high.append(col)
-                    else:
-                        categorical_low.append(col)
-        else:
-            for i in range(X.shape[1]):
-                col = X[:, i]
-                nunique = len(np.unique(col))
-                if np.issubdtype(col.dtype, np.datetime64):
-                    datetime_cols.append(i)
-                elif np.issubdtype(col.dtype, np.number):
-                    if nunique > numeric_threshold:
-                        numeric.append(i)
-                    elif nunique > cardinality_threshold:
-                        categorical_high.append(i)
-                    else:
-                        categorical_low.append(i)
-                else:
-                    if nunique > cardinality_threshold:
-                        categorical_high.append(i)
-                    else:
-                        categorical_low.append(i)
-
-        self.feature_types = {
-            "numeric": numeric,
-            "categorical_high": categorical_high,
-            "categorical_low": categorical_low,
-            "datetime": datetime_cols,
-        }
         self.inferred_types_df = pd.DataFrame.from_dict(
             self.feature_types, orient="index"
         ).T.fillna("")
-        return numeric, categorical_high, categorical_low, datetime_cols
+        return (
+            self.feature_types["numeric"],
+            self.feature_types["categorical_high"],
+            self.feature_types["categorical_low"],
+            self.feature_types["datetime"],
+        )
 
     def __repr__(self):
         return non_default_repr(self)

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -35,7 +35,8 @@ from .datetime import DatetimeEncoder
 if TYPE_CHECKING:
     pass
 
-__all__ = ['PoniardPreprocessor']
+__all__ = ["PoniardPreprocessor"]
+
 
 class PoniardPreprocessor:
     """Base preprocessor that builds an easily modifiable pipeline based
@@ -102,9 +103,7 @@ class PoniardPreprocessor:
         self._cache_tempdir = None
         if cache_transformations:
             if cache_dir is None:
-                self._cache_tempdir = tempfile.TemporaryDirectory(
-                    prefix="poniard_cache_"
-                )
+                self._cache_tempdir = tempfile.TemporaryDirectory(prefix="poniard_cache_")
                 cache_dir = self._cache_tempdir.name
             self._memory = joblib.Memory(str(cache_dir), verbose=self.verbose)
         else:
@@ -214,9 +213,7 @@ class PoniardPreprocessor:
                     ],
                     n_jobs=self.n_jobs,
                 )
-        non_empty_transformers = [
-            x for x in type_preprocessor.transformers if x[2] != []
-        ]
+        non_empty_transformers = [x for x in type_preprocessor.transformers if x[2] != []]
         type_preprocessor.transformers = non_empty_transformers
         if len(type_preprocessor.transformers) == 1:
             type_preprocessor = type_preprocessor.transformers[0][1]
@@ -295,17 +292,13 @@ class PoniardPreprocessor:
         else:
             num_imputer = SimpleImputer(strategy="mean")
 
-        numeric_preprocessor = Pipeline(
-            [("numeric_imputer", num_imputer), ("scaler", scaler)]
-        )
+        numeric_preprocessor = Pipeline([("numeric_imputer", num_imputer), ("scaler", scaler)])
         cat_low_preprocessor = Pipeline(
             [
                 ("categorical_imputer", cat_date_imputer),
                 (
                     "one-hot_encoder",
-                    OneHotEncoder(
-                        drop="if_binary", handle_unknown="ignore", sparse_output=False
-                    ),
+                    OneHotEncoder(drop="if_binary", handle_unknown="ignore", sparse_output=False),
                 ),
             ]
         )

--- a/poniard/preprocessing/datetime.py
+++ b/poniard/preprocessing/datetime.py
@@ -8,7 +8,7 @@ import pandas as pd
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import validate_data
 
-__all__ = ['DatetimeEncoder']
+__all__ = ["DatetimeEncoder"]
 
 
 class DateLevel(Enum):
@@ -45,9 +45,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
         Follows standard Pandas/stdlib formatting, e.g. '%Y-%m-%d %H:%M:%S'.
     """
 
-    def __init__(
-        self, levels: Sequence[DateLevel] | None = None, fmt: str | None = None
-    ):
+    def __init__(self, levels: Sequence[DateLevel] | None = None, fmt: str | None = None):
         self.levels = levels
         self.fmt = fmt
 
@@ -71,8 +69,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
                 pd.api.types.is_datetime64_any_dtype(dt) for dt in X.dtypes
             ):
                 raise ValueError(
-                    "If data contains more than one type, "
-                    "they all have to be datetime64 (any)."
+                    "If data contains more than one type, they all have to be datetime64 (any)."
                 )
             elif X.dtypes.iloc[0] in (object, str):
                 X = X.apply(pd.to_datetime, format=self.fmt)
@@ -96,9 +93,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
 
         self.n_features_in_ = X.shape[1]
         self.feature_names_in_ = input_names
-        self.n_features_out_ = sum(
-            len(features) for features in self.valid_features_.values()
-        )
+        self.n_features_out_ = sum(len(features) for features in self.valid_features_.values())
         return self
 
     def transform(self, X: pd.DataFrame | np.ndarray | list) -> np.ndarray:
@@ -119,8 +114,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
                 pd.api.types.is_datetime64_any_dtype(dt) for dt in X.dtypes
             ):
                 raise ValueError(
-                    "If data contains more than one type, "
-                    "they all have to be datetime64 (any)."
+                    "If data contains more than one type, they all have to be datetime64 (any)."
                 )
             elif X.dtypes.iloc[0] in (object, str):
                 X = X.apply(pd.to_datetime, format=self.fmt)

--- a/poniard/utils/estimate.py
+++ b/poniard/utils/estimate.py
@@ -16,9 +16,7 @@ def get_target_info(y: pd.DataFrame | pd.Series | np.ndarray, task: str) -> dict
     # dataset is 'multiclass' according to this function when it should be 'continuous'.
     if type_of_target_ == "multiclass" and task == "regression":
         type_of_target_ = "continuous"
-    return dict(
-        type_=type_of_target_, ndim=y.ndim, shape=y.shape, nunique=np.unique(y).size
-    )
+    return dict(type_=type_of_target_, ndim=y.ndim, shape=y.shape, nunique=np.unique(y).size)
 
 
 def element_to_list_maybe(obj):

--- a/poniard/utils/estimate.py
+++ b/poniard/utils/estimate.py
@@ -6,6 +6,24 @@ import numpy as np
 import pandas as pd
 from sklearn.utils.multiclass import type_of_target
 
+try:
+    import polars as pl
+except ImportError:
+    pl = None
+
+
+def coerce_input(X):
+    """Convert polars input to pandas and coerce other sequences to numpy.
+
+    Shared by the estimator and preprocessor configuration paths so both
+    accept the same input types (polars, pandas, numpy, lists).
+    """
+    if pl is not None and isinstance(X, (pl.DataFrame, pl.Series)):
+        X = X.to_pandas()
+    if not isinstance(X, (pd.DataFrame, pd.Series, np.ndarray)):
+        X = np.array(X)
+    return X
+
 
 def get_target_info(y: pd.DataFrame | pd.Series | np.ndarray, task: str) -> dict:
     """Return a dict containing basic information about the target array."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0", "setuptools-scm>=8.0"]
+requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -38,12 +38,6 @@ dependencies = [
 
 [project.optional-dependencies]
 plot = ["plotly"]
-dev = [
-    "pytest",
-    "ruff",
-    "pre-commit",
-    "poniard[plot]",
-]
 
 [project.urls]
 Homepage = "https://github.com/rxavier/poniard"
@@ -64,9 +58,23 @@ per-file-ignores = {"poniard/**/__init__.py" = ["F401"]}
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.coverage.run]
+source = ["poniard"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 85
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@abstractmethod",
+]
+
 [dependency-groups]
 dev = [
     "pytest",
+    "pytest-cov",
     "ruff>=0.16.0",
     "pre-commit",
     "poniard[plot]",

--- a/tests/test_compare_pareto.py
+++ b/tests/test_compare_pareto.py
@@ -13,9 +13,7 @@ N = 100
 
 @pytest.fixture
 def fitted_clf():
-    X, y = make_classification(
-        n_samples=N, n_features=5, random_state=42, n_informative=3
-    )
+    X, y = make_classification(n_samples=N, n_features=5, random_state=42, n_informative=3)
     X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
     clf = PoniardClassifier(
         estimators={

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,9 +57,7 @@ def test_classifier_fit(target, metrics, estimators, cv):
     features.columns = features.columns.astype(str)
     features["strings"] = np.random.choice(["a", "b", "c"], size=len(target))
     features["dates"] = pd.date_range("2020-01-01", periods=len(target))
-    clf = PoniardClassifier(
-        estimators=estimators, cv=cv, metrics=metrics, random_state=0
-    )
+    clf = PoniardClassifier(estimators=estimators, cv=cv, metrics=metrics, random_state=0)
     clf.setup(features, target)
     clf.fit(features, target)
     results = clf.get_results(return_train_scores=True)
@@ -95,9 +93,7 @@ def test_classifier_fit(target, metrics, estimators, cv):
             np.random.normal(size=(20,)),
             {
                 "mse": make_scorer(mean_squared_error, greater_is_better=False),
-                "mape": make_scorer(
-                    mean_absolute_percentage_error, greater_is_better=False
-                ),
+                "mape": make_scorer(mean_absolute_percentage_error, greater_is_better=False),
             },
             [LinearRegression(), RandomForestRegressor()],
             KFold(n_splits=3),
@@ -109,9 +105,7 @@ def test_regressor_fit(target, metrics, estimators, cv):
     features.columns = features.columns.astype(str)
     features["strings"] = np.random.choice(["a", "b", "c"], size=len(target))
     features["dates"] = pd.date_range("2020-01-01", periods=len(target))
-    clf = PoniardRegressor(
-        estimators=estimators, cv=cv, metrics=metrics, random_state=0
-    )
+    clf = PoniardRegressor(estimators=estimators, cv=cv, metrics=metrics, random_state=0)
     clf.setup(features, target)
     clf.fit(features, target)
     results = clf.get_results(return_train_scores=True)
@@ -129,6 +123,7 @@ def test_regressor_fit(target, metrics, estimators, cv):
 
 def test_multilabel_fit():
     import warnings
+
     X, y = make_multilabel_classification(n_samples=1000, n_classes=3, n_labels=3)
     clf = PoniardClassifier(
         estimators={
@@ -148,6 +143,7 @@ def test_multilabel_fit():
 
 def test_multioutput_fit():
     import warnings
+
     X, y = make_regression(n_targets=3)
     clf = PoniardRegressor(
         estimators={
@@ -174,9 +170,7 @@ def test_type_inference():
             "high_cardinality_str": [str(x) for x in range(10)],
             "high_cardinality_int": [x for x in range(10)],
             "datetime_H": pd.date_range("2020-01-01", freq="h", periods=10),
-            "datetime_D": pd.date_range(
-                "2020-01-01", freq="D", periods=10, tz="Europe/Moscow"
-            ),
+            "datetime_D": pd.date_range("2020-01-01", freq="D", periods=10, tz="Europe/Moscow"),
         }
     )
     # Add random nan to 10% per column: https://stackoverflow.com/a/61018279
@@ -192,12 +186,8 @@ def test_type_inference():
     )
     clf.setup(x, y)
     clf.fit(x, y)
-    assert all(
-        x in clf.feature_types["numeric"] for x in ["numeric", "high_cardinality_int"]
-    )
-    assert all(
-        x in clf.feature_types["categorical_high"] for x in ["high_cardinality_str"]
-    )
+    assert all(x in clf.feature_types["numeric"] for x in ["numeric", "high_cardinality_int"])
+    assert all(x in clf.feature_types["categorical_high"] for x in ["high_cardinality_str"])
     assert all(
         x in clf.feature_types["categorical_low"]
         for x in ["low_cardinality_str", "low_cardinality_int"]

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -26,9 +26,7 @@ def test_ensemble(method, estimator_names, top_n, sort_by):
     )
     reg.setup(x, y)
     reg.fit(x, y)
-    reg.build_ensemble(
-        method=method, estimator_names=estimator_names, top_n=top_n, sort_by=sort_by
-    )
+    reg.build_ensemble(method=method, estimator_names=estimator_names, top_n=top_n, sort_by=sort_by)
     reg.fit(x, y)
     results = reg.get_results()
     ensemble_class_name = method.capitalize() + "Regressor"
@@ -42,7 +40,8 @@ def test_ensemble(method, estimator_names, top_n, sort_by):
     else:
         sorter = sort_by or results.columns[0]
         sorted_names = [
-            n for n in results.sort_values(sorter, ascending=False).index
+            n
+            for n in results.sort_values(sorter, ascending=False).index
             if n != ensemble_class_name and n not in dummy
         ]
         assert all(x in ensemble_estimators for x in sorted_names[:top_n])
@@ -96,7 +95,9 @@ def test_ensemble_top_n_strategy():
         random_state=0,
     )
     clf.fit(X, y)
-    clf.build_ensemble(method="voting", strategy="top_n", top_n=2, ensemble_name="topn", voting="soft")
+    clf.build_ensemble(
+        method="voting", strategy="top_n", top_n=2, ensemble_name="topn", voting="soft"
+    )
     clf.fit(X, y)
     results = clf.get_results()
     assert "topn" in results.index
@@ -117,7 +118,9 @@ def test_ensemble_diversity_fallback_to_top_n():
         random_state=0,
     )
     clf.fit(X, y)
-    clf.build_ensemble(method="voting", strategy="diversity", top_n=2, ensemble_name="fallback", voting="soft")
+    clf.build_ensemble(
+        method="voting", strategy="diversity", top_n=2, ensemble_name="fallback", voting="soft"
+    )
     clf.fit(X, y)
     results = clf.get_results()
     assert "fallback" in results.index
@@ -128,7 +131,9 @@ def test_ensemble_diversity_single_estimator():
     n = 30
     X = pd.DataFrame(np.random.normal(size=(n, 3)))
     y = np.random.choice([0, 1], size=n)
-    clf = PoniardClassifier(estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0)
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0
+    )
     clf.fit(X, y)
     selected = clf._select_diverse(top_n=3, sort_by=None, similarity_threshold=0.5, X=X, y=y)
     assert len(selected) >= 1
@@ -139,7 +144,9 @@ def test_ensemble_invalid_strategy():
     n = 30
     X = pd.DataFrame(np.random.normal(size=(n, 3)))
     y = np.random.choice([0, 1], size=n)
-    clf = PoniardClassifier(estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0)
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=1000)}, cv=2, random_state=0
+    )
     clf.fit(X, y)
     with pytest.raises(ValueError, match="Strategy"):
         clf.build_ensemble(strategy="invalid", X=X, y=y)
@@ -151,9 +158,7 @@ def test_predictions_similarity(reg_or_clf, on_errors):
         est = PoniardRegressor(estimators=[LinearRegression(), DecisionTreeRegressor()])
         y = np.random.normal(size=10)
     else:
-        est = PoniardClassifier(
-            estimators=[LogisticRegression(), DecisionTreeClassifier()]
-        )
+        est = PoniardClassifier(estimators=[LogisticRegression(), DecisionTreeClassifier()])
         y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1])
     x = pd.DataFrame(np.random.normal(size=(len(y), 5)))
     est.setup(x, y)

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -26,9 +26,7 @@ def binary_data():
         }
     )
     y = pd.Series(np.random.choice([0, 1], size=N))
-    clf = PoniardClassifier(
-        estimators={"lr": LogisticRegression()}, cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators={"lr": LogisticRegression()}, cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     return clf, X, y
@@ -55,9 +53,7 @@ def multiclass_data():
 
 @pytest.fixture
 def multilabel_data():
-    X, y = make_multilabel_classification(
-        n_samples=N, n_features=3, n_classes=3, random_state=0
-    )
+    X, y = make_multilabel_classification(n_samples=N, n_features=3, n_classes=3, random_state=0)
     X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
     clf = PoniardClassifier(
         estimators={"lr": OneVsRestClassifier(LogisticRegression(max_iter=5000))},
@@ -80,9 +76,7 @@ def reg_data():
         }
     )
     y = pd.Series(np.random.normal(size=N))
-    reg = PoniardRegressor(
-        estimators={"lr": LinearRegression()}, cv=2, random_state=0
-    )
+    reg = PoniardRegressor(estimators={"lr": LinearRegression()}, cv=2, random_state=0)
     reg.setup(X, y)
     reg.fit(X, y)
     return reg, X, y
@@ -90,14 +84,10 @@ def reg_data():
 
 @pytest.fixture
 def multioutput_reg_data():
-    X, y = make_regression(
-        n_samples=N, n_features=3, n_targets=2, random_state=0
-    )
+    X, y = make_regression(n_samples=N, n_features=3, n_targets=2, random_state=0)
     X = pd.DataFrame(X, columns=[f"f{i}" for i in range(X.shape[1])])
     y = pd.DataFrame(y, columns=[f"t{i}" for i in range(y.shape[1])])
-    reg = PoniardRegressor(
-        estimators={"lr": LinearRegression()}, cv=2, random_state=0
-    )
+    reg = PoniardRegressor(estimators={"lr": LinearRegression()}, cv=2, random_state=0)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
         reg.setup(X, y)
@@ -190,8 +180,38 @@ class TestRankErrors:
     def test_standalone_mode(self):
         n = 30
         y = np.array(
-            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-             1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+            [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+                1,
+            ]
         )
         predictions = np.zeros(n, dtype=int)
         probas = np.array([[0.9, 0.1]] * 15 + [[0.6, 0.4]] * 15)
@@ -291,9 +311,7 @@ class TestAnalyzeFeatures:
         ea = _make_ea(clf)
         errors = ea.rank_errors(X=X, y=y)
         merged = ErrorAnalyzer.merge_errors(errors)
-        summary = ea.analyze_features(
-            errors_idx=merged.index, X=X, features=["a", "b"]
-        )
+        summary = ea.analyze_features(errors_idx=merged.index, X=X, features=["a", "b"])
         assert set(summary.keys()) == {"a", "b"}
 
     def test_with_feature_subset_by_index(self, binary_data):
@@ -365,17 +383,13 @@ class TestAnalyzeFeatures:
         errors = ea.rank_errors(X=X, y=y)
         merged = ErrorAnalyzer.merge_errors(errors)
         with pytest.raises(ValueError, match="y"):
-            ea.analyze_features(
-                errors_idx=merged.index, X=X, estimator_name="lr"
-            )
+            ea.analyze_features(errors_idx=merged.index, X=X, estimator_name="lr")
 
     def test_estimator_name_requires_from_poniard(self, reg_data):
         clf, X, y = reg_data
         ea = ErrorAnalyzer(task="regression")
         with pytest.raises(ValueError, match="from_poniard"):
-            ea.analyze_features(
-                errors_idx=pd.Index([0]), X=X, y=y, estimator_name="lr"
-            )
+            ea.analyze_features(errors_idx=pd.Index([0]), X=X, y=y, estimator_name="lr")
 
     def test_categorical_known_error_region(self):
         """Errors confined to one category must surface as a high error_rate."""

--- a/tests/test_error_analysis.py
+++ b/tests/test_error_analysis.py
@@ -574,3 +574,62 @@ def test_analyze_multiclass_string_labels():
     clf.fit(X, y)
     report = ErrorAnalyzer.from_poniard(clf).analyze(X, y)
     assert set(report.summary.index) == {"lr"}
+
+
+def test_analyze_caches_cv_predictions():
+    """Repeated analyze() must reuse cached CV predictions, not rerun them."""
+    from unittest import mock
+
+    from sklearn.model_selection import cross_val_predict as real_cross_val_predict
+
+    X = pd.DataFrame({"a": np.random.normal(size=N), "b": np.random.normal(size=N)})
+    y = pd.Series(np.random.choice([0, 1], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    ea = ErrorAnalyzer.from_poniard(clf)
+
+    with mock.patch(
+        "poniard.estimators.core.cross_val_predict", wraps=real_cross_val_predict
+    ) as spy:
+        ea.analyze(X=X, y=y)
+        first = spy.call_count
+        ea.analyze(X=X, y=y)
+        second = spy.call_count
+
+    # One proba CV pass per estimator on the first analyze; none on the second.
+    assert first == len(ea.estimator_names)
+    assert second == first
+
+
+def test_proba_derived_predictions_match_predict():
+    """Hard predictions derived from probas must equal the CV predict output."""
+    X = pd.DataFrame({"a": np.random.normal(size=N), "b": np.random.normal(size=N)})
+    y = pd.Series(np.random.choice([0, 1], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    clf.fit(X, y)
+    ea = ErrorAnalyzer.from_poniard(clf)
+
+    predictions, probas = ea._compute_predictions(X, y)
+    hard = clf.predict(X=X, y=y)
+    for name in predictions:
+        np.testing.assert_array_equal(predictions[name], hard[name])
+    assert probas["lr"].shape == (N, 2)
+
+
+def test_analyze_falls_back_without_predict_proba():
+    """Estimators lacking predict_proba must still be analyzed via predict()."""
+    from sklearn.svm import LinearSVC
+
+    X = pd.DataFrame({"a": np.random.normal(size=N), "b": np.random.normal(size=N)})
+    y = pd.Series(np.random.choice([0, 1], size=N))
+    clf = PoniardClassifier(estimators={"svc": LinearSVC(max_iter=5000)}, cv=2, random_state=0)
+    clf.setup(X, y)
+    clf.fit(X, y)
+    report = ErrorAnalyzer.from_poniard(clf).analyze(X=X, y=y)
+    assert "svc" in report.summary.index

--- a/tests/test_fitted_tracking.py
+++ b/tests/test_fitted_tracking.py
@@ -10,9 +10,7 @@ Y = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1])
 
 def _clf():
     x = pd.DataFrame(np.random.normal(size=(len(Y), 5)))
-    return PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    ), x
+    return PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0), x
 
 
 def test_fit_tracks_pipeline_names():

--- a/tests/test_get_estimator.py
+++ b/tests/test_get_estimator.py
@@ -27,9 +27,7 @@ def _data():
 
 def _fitted_clf():
     X, y = _data()
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     return clf, X, y
@@ -46,9 +44,7 @@ def test_get_estimator_without_preprocessor_is_bare_estimator():
     n = 50
     X = pd.DataFrame(np.random.normal(size=(n, 2)), columns=["a", "b"])
     y = pd.Series(np.random.choice([0, 1], size=n))
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     est = clf.get_estimator(

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -21,6 +21,7 @@ from poniard.preprocessing import PoniardPreprocessor
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def iris_binary():
     """Iris dataset reduced to binary (setosa vs versicolor), 4 numeric features."""
@@ -36,14 +37,16 @@ def mixed_df():
     """DataFrame with numeric, string, boolean, and datetime columns."""
     rng = np.random.RandomState(42)
     n = 60
-    return pd.DataFrame({
-        "num_high": rng.normal(size=n),                     # numeric (many unique)
-        "num_low": rng.choice([1, 2, 3], size=n),           # numeric few unique -> cat_low
-        "str_low": rng.choice(["a", "b", "c"], size=n),     # string low cardinality
-        "str_high": [f"cat_{i}" for i in range(n)],         # string high cardinality
-        "bool_col": rng.choice([True, False], size=n),       # boolean
-        "dt": pd.date_range("2020-01-01", periods=n),       # datetime
-    }), pd.Series(rng.choice([0, 1], size=n), name="target")
+    return pd.DataFrame(
+        {
+            "num_high": rng.normal(size=n),  # numeric (many unique)
+            "num_low": rng.choice([1, 2, 3], size=n),  # numeric few unique -> cat_low
+            "str_low": rng.choice(["a", "b", "c"], size=n),  # string low cardinality
+            "str_high": [f"cat_{i}" for i in range(n)],  # string high cardinality
+            "bool_col": rng.choice([True, False], size=n),  # boolean
+            "dt": pd.date_range("2020-01-01", periods=n),  # datetime
+        }
+    ), pd.Series(rng.choice([0, 1], size=n), name="target")
 
 
 @pytest.fixture
@@ -85,6 +88,7 @@ def fitted_regressor(regression_data):
 # ===========================================================================
 # 1. Type inference tests
 # ===========================================================================
+
 
 class TestTypeInference:
     def test_numeric_many_unique_values_classified_as_numeric(self):
@@ -170,7 +174,10 @@ class TestTypeInference:
         preprocessor = PoniardPreprocessor()
         preprocessor.build(X=X, y=y, task="classification")
         assert set(preprocessor.feature_types.keys()) == {
-            "numeric", "categorical_high", "categorical_low", "datetime"
+            "numeric",
+            "categorical_high",
+            "categorical_low",
+            "datetime",
         }
 
     def test_numeric_threshold_as_float(self):
@@ -206,14 +213,17 @@ class TestTypeInference:
 # 2. Preprocessing tests
 # ===========================================================================
 
+
 class TestPreprocessing:
     def test_default_preprocessor_has_expected_structure(self):
         """Default preprocessor should be a Pipeline with type_preprocessor and VarianceThreshold."""
         n = 50
-        X = pd.DataFrame({
-            "num": np.random.normal(size=n),
-            "cat": np.random.choice(["a", "b"], size=n),
-        })
+        X = pd.DataFrame(
+            {
+                "num": np.random.normal(size=n),
+                "cat": np.random.choice(["a", "b"], size=n),
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         pp = PoniardPreprocessor()
@@ -237,7 +247,9 @@ class TestPreprocessing:
         else:
             # Single transformer — the whole preprocessor IS the numeric one
             numeric_pipeline = ct
-        step_names = [s for s, _ in numeric_pipeline.steps] if hasattr(numeric_pipeline, 'steps') else []
+        step_names = (
+            [s for s, _ in numeric_pipeline.steps] if hasattr(numeric_pipeline, "steps") else []
+        )
         has_scaler = any("scaler" in s.lower() for s in step_names)
         assert has_scaler or isinstance(numeric_pipeline, Pipeline)
 
@@ -253,10 +265,12 @@ class TestPreprocessing:
         """Categorical low should get OneHotEncoder."""
         n = 50
         rng = np.random.RandomState(0)
-        X = pd.DataFrame({
-            "num": rng.normal(size=n),
-            "cat": rng.choice(["a", "b", "c"], size=n),
-        })
+        X = pd.DataFrame(
+            {
+                "num": rng.normal(size=n),
+                "cat": rng.choice(["a", "b", "c"], size=n),
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         pp = PoniardPreprocessor()
@@ -271,10 +285,12 @@ class TestPreprocessing:
         """Categorical high should get TargetEncoder by default."""
         n = 60
         rng = np.random.RandomState(0)
-        X = pd.DataFrame({
-            "num": rng.normal(size=n),
-            "high": [f"cat_{i}" for i in range(n)],
-        })
+        X = pd.DataFrame(
+            {
+                "num": rng.normal(size=n),
+                "high": [f"cat_{i}" for i in range(n)],
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         pp = PoniardPreprocessor(cardinality_threshold=5)
@@ -303,7 +319,7 @@ class TestPreprocessing:
         assert isinstance(clf.preprocessor, Pipeline)
         assert "imputer" in clf.preprocessor.named_steps or "imputer" in dict(
             clf.preprocessor.named_steps.get("type_preprocessor", {}).steps
-            if hasattr(clf.preprocessor.named_steps.get("type_preprocessor"), 'steps')
+            if hasattr(clf.preprocessor.named_steps.get("type_preprocessor"), "steps")
             else []
         )
 
@@ -329,10 +345,12 @@ class TestPreprocessing:
         """When high_cardinality_encoder='ordinal', OrdinalEncoder should be used."""
         n = 60
         rng = np.random.RandomState(0)
-        X = pd.DataFrame({
-            "num": rng.normal(size=n),
-            "high": [f"cat_{i}" for i in range(n)],
-        })
+        X = pd.DataFrame(
+            {
+                "num": rng.normal(size=n),
+                "high": [f"cat_{i}" for i in range(n)],
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         pp = PoniardPreprocessor(high_cardinality_encoder="ordinal", cardinality_threshold=5)
@@ -349,10 +367,12 @@ class TestPreprocessing:
 
         n = 50
         rng = np.random.RandomState(0)
-        X = pd.DataFrame({
-            "num": rng.normal(size=n),
-            "dt": pd.date_range("2020-01-01", periods=n),
-        })
+        X = pd.DataFrame(
+            {
+                "num": rng.normal(size=n),
+                "dt": pd.date_range("2020-01-01", periods=n),
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         pp = PoniardPreprocessor()
@@ -366,6 +386,7 @@ class TestPreprocessing:
 # ===========================================================================
 # 3. Results tests
 # ===========================================================================
+
 
 class TestResults:
     def test_get_results_returns_dataframe(self, fitted_classifier):
@@ -472,10 +493,12 @@ class TestResults:
 # 4. Estimator management tests
 # ===========================================================================
 
+
 class TestEstimatorManagement:
     def test_add_estimators_adds_to_pipelines(self, fitted_classifier):
         """add_estimators should add new pipelines."""
         from sklearn.tree import DecisionTreeClassifier
+
         initial_count = len(fitted_classifier.pipelines)
         fitted_classifier.add_estimators([DecisionTreeClassifier()])
         assert len(fitted_classifier.pipelines) == initial_count + 1
@@ -504,8 +527,6 @@ class TestEstimatorManagement:
         est = fitted_classifier.get_estimator("LogisticRegression", include_preprocessor=False)
         assert isinstance(est, LogisticRegression)
 
-
-
     def test_remove_all_estimators_raises(self, fitted_classifier):
         """Removing all estimators should raise ValueError."""
         all_names = list(fitted_classifier.pipelines.keys())
@@ -522,6 +543,7 @@ class TestEstimatorManagement:
 # ===========================================================================
 # 5. Ensemble tests
 # ===========================================================================
+
 
 class TestEnsemble:
     def test_voting_ensemble_classification(self, fitted_classifier):
@@ -596,6 +618,7 @@ class TestEnsemble:
 # 6. Edge cases
 # ===========================================================================
 
+
 class TestEdgeCases:
     def test_single_feature_dataset(self):
         """Classifier should work with a single numeric feature."""
@@ -628,10 +651,12 @@ class TestEdgeCases:
     def test_all_nan_columns(self):
         """DataFrame with all-NaN columns should handle gracefully."""
         n = 50
-        X = pd.DataFrame({
-            "nan_col": [np.nan] * n,
-            "valid_col": np.random.normal(size=n),
-        })
+        X = pd.DataFrame(
+            {
+                "nan_col": [np.nan] * n,
+                "valid_col": np.random.normal(size=n),
+            }
+        )
         y = np.zeros(n, dtype=int)
         y[::2] = 1
         clf = PoniardClassifier(
@@ -640,8 +665,11 @@ class TestEdgeCases:
             random_state=42,
         )
         import warnings
+
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="Skipping features without any observed values")
+            warnings.filterwarnings(
+                "ignore", message="Skipping features without any observed values"
+            )
             clf.fit(X, y)
         results = clf.get_results()
         assert results.shape[0] == 2
@@ -718,14 +746,10 @@ class TestEdgeCases:
         )
         y = np.array([0, 1] * (n // 2))
 
-        setup_clf = PoniardClassifier(
-            estimators=[LogisticRegression()], cv=2, random_state=42
-        )
+        setup_clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=42)
         setup_clf.setup(X, y)
 
-        fit_clf = PoniardClassifier(
-            estimators=[LogisticRegression()], cv=2, random_state=42
-        )
+        fit_clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=42)
         fit_clf.fit(X, y)
 
         assert setup_clf.feature_types == fit_clf.feature_types
@@ -750,6 +774,7 @@ class TestEdgeCases:
     def test_verbose_propagation(self):
         """verbose should be propagated to estimators that support it."""
         from sklearn.ensemble import RandomForestClassifier
+
         n = 50
         X = pd.DataFrame({"a": np.random.normal(size=n), "b": np.random.normal(size=n)})
         y = np.array([0, 1] * (n // 2))

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -13,9 +13,7 @@ def clf_setup():
     n = 60
     X = pd.DataFrame(np.random.normal(size=(n, 4)), columns=list("abcd"))
     y = pd.Series(np.random.choice([0, 1], size=n))
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     return X, y, clf
@@ -26,9 +24,7 @@ def reg_setup():
     n = 60
     X = pd.DataFrame(np.random.normal(size=(n, 4)), columns=list("abcd"))
     y = pd.Series(np.random.normal(size=n))
-    reg = PoniardRegressor(
-        estimators=[LinearRegression()], cv=2, random_state=0
-    )
+    reg = PoniardRegressor(estimators=[LinearRegression()], cv=2, random_state=0)
     reg.setup(X, y)
     reg.fit(X, y)
     return X, y, reg
@@ -76,16 +72,12 @@ class TestClassifierPlots:
 
     def test_partial_dependence(self, clf_setup):
         X, y, clf = clf_setup
-        fig = PoniardPlotFactory(X, y, clf).partial_dependence(
-            "LogisticRegression", feature=0
-        )
+        fig = PoniardPlotFactory(X, y, clf).partial_dependence("LogisticRegression", feature=0)
         assert isinstance(fig, go.Figure)
 
     def test_full_estimator_analysis(self, clf_setup):
         X, y, clf = clf_setup
-        fig = PoniardPlotFactory(X, y, clf).full_estimator_analysis(
-            "LogisticRegression"
-        )
+        fig = PoniardPlotFactory(X, y, clf).full_estimator_analysis("LogisticRegression")
         assert isinstance(fig, go.Figure)
 
 
@@ -102,16 +94,12 @@ class TestRegressorPlots:
 
     def test_permutation_importance(self, reg_setup):
         X, y, reg = reg_setup
-        fig = PoniardPlotFactory(X, y, reg).permutation_importance(
-            "LinearRegression", n_repeats=2
-        )
+        fig = PoniardPlotFactory(X, y, reg).permutation_importance("LinearRegression", n_repeats=2)
         assert isinstance(fig, go.Figure)
 
     def test_partial_dependence(self, reg_setup):
         X, y, reg = reg_setup
-        fig = PoniardPlotFactory(X, y, reg).partial_dependence(
-            "LinearRegression", feature=0
-        )
+        fig = PoniardPlotFactory(X, y, reg).partial_dependence("LinearRegression", feature=0)
         assert isinstance(fig, go.Figure)
 
     def test_residuals(self, reg_setup):
@@ -121,16 +109,12 @@ class TestRegressorPlots:
 
     def test_residuals_histogram(self, reg_setup):
         X, y, reg = reg_setup
-        fig = PoniardPlotFactory(X, y, reg).residuals_histogram(
-            ["LinearRegression"]
-        )
+        fig = PoniardPlotFactory(X, y, reg).residuals_histogram(["LinearRegression"])
         assert isinstance(fig, go.Figure)
 
     def test_full_estimator_analysis(self, reg_setup):
         X, y, reg = reg_setup
-        fig = PoniardPlotFactory(X, y, reg).full_estimator_analysis(
-            "LinearRegression"
-        )
+        fig = PoniardPlotFactory(X, y, reg).full_estimator_analysis("LinearRegression")
         assert isinstance(fig, go.Figure)
 
 
@@ -141,9 +125,7 @@ class TestNewPlots:
         X, y, clf = clf_setup
         ea = ErrorAnalyzer.from_poniard(clf)
         report = ea.analyze(X=X, y=y)
-        fig = PoniardPlotFactory(X, y, clf).error_lift_bars(
-            lift_by_target=report.lift_by_target
-        )
+        fig = PoniardPlotFactory(X, y, clf).error_lift_bars(lift_by_target=report.lift_by_target)
         assert isinstance(fig, go.Figure)
 
     def test_error_lift_bars_top_n(self, clf_setup):
@@ -169,9 +151,7 @@ class TestNewPlots:
 
     def test_similarity_heatmap_on_predictions(self, clf_setup):
         X, y, clf = clf_setup
-        fig = PoniardPlotFactory(X, y, clf).similarity_heatmap(
-            X, y, on_errors=False
-        )
+        fig = PoniardPlotFactory(X, y, clf).similarity_heatmap(X, y, on_errors=False)
         assert isinstance(fig, go.Figure)
 
     def test_similarity_heatmap_regressor(self, reg_setup):
@@ -191,7 +171,5 @@ class TestNewPlots:
 
     def test_time_quality_scatter_custom_metric(self, clf_setup):
         X, y, clf = clf_setup
-        fig = PoniardPlotFactory(X, y, clf).time_quality_scatter(
-            metric="test_accuracy"
-        )
+        fig = PoniardPlotFactory(X, y, clf).time_quality_scatter(metric="test_accuracy")
         assert isinstance(fig, go.Figure)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -112,9 +112,7 @@ def test_preprocessing_classifier(
     train_results = estimator.get_results(return_train_scores=True)
     assert any(c.startswith("train_") for c in train_results.columns)
     assert isinstance(
-        estimator.get_estimator(
-            "LogisticRegression", include_preprocessor=include_preprocessor
-        ),
+        estimator.get_estimator("LogisticRegression", include_preprocessor=include_preprocessor),
         BaseEstimator,
     )
 

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -39,7 +39,7 @@ def test_save_load_round_trip_classifier(tmp_path):
 
     assert isinstance(loaded, PoniardClassifier)
     pd.testing.assert_frame_equal(loaded.get_results(), results_before)
-    assert loaded._experiment_results.keys() == clf._experiment_results.keys()
+    assert loaded._cv_results.keys() == clf._cv_results.keys()
 
 
 def test_save_load_round_trip_regressor(tmp_path):

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -26,9 +26,7 @@ def _reg_data():
 
 def test_save_load_round_trip_classifier(tmp_path):
     X, y = _clf_data()
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     results_before = clf.get_results()
@@ -44,9 +42,7 @@ def test_save_load_round_trip_classifier(tmp_path):
 
 def test_save_load_round_trip_regressor(tmp_path):
     X, y = _reg_data()
-    reg = PoniardRegressor(
-        estimators=[LinearRegression()], cv=2, random_state=0
-    )
+    reg = PoniardRegressor(estimators=[LinearRegression()], cv=2, random_state=0)
     reg.setup(X, y)
     reg.fit(X, y)
     results_before = reg.get_results()
@@ -61,25 +57,19 @@ def test_save_load_round_trip_regressor(tmp_path):
 
 def test_loaded_estimator_can_export_pipeline(tmp_path):
     X, y = _clf_data()
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     path = tmp_path / "clf.joblib"
     clf.save(path)
     loaded = PoniardClassifier.load(path)
-    model = loaded.get_estimator(
-        "LogisticRegression", retrain=True, X=X, y=y
-    )
+    model = loaded.get_estimator("LogisticRegression", retrain=True, X=X, y=y)
     assert len(model.predict(X)) == len(X)
 
 
 def test_save_load_after_tuning(tmp_path):
     X, y = _clf_data()
-    clf = PoniardClassifier(
-        estimators=[LogisticRegression()], cv=2, random_state=0
-    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=2, random_state=0)
     clf.setup(X, y)
     clf.fit(X, y)
     clf.tune_estimator(

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -213,3 +213,41 @@ def test_plot_factory_does_not_fit_stored_pipelines():
 
     plotter.partial_dependence("LogisticRegression", feature=0)
     assert not hasattr(clf.pipelines["LogisticRegression"], "classes_")
+
+
+def test_does_not_mutate_user_estimators_or_cv():
+    """User-supplied estimators and CV splitters must not be mutated."""
+    from sklearn.model_selection import KFold
+
+    lr = LogisticRegression()
+    kf = KFold(n_splits=2, shuffle=True, random_state=123)
+    X = pd.DataFrame(np.random.normal(size=(30, 3)), columns=list("abc"))
+    y = np.random.choice([0, 1], size=30)
+
+    clf = PoniardClassifier(estimators=[lr], cv=kf, random_state=0)
+    clf.setup(X, y)
+    clf.fit(X, y)
+
+    assert lr.random_state is None
+    assert kf.random_state == 123
+    assert clf.cv is not kf
+
+
+def test_does_not_mutate_custom_preprocessor():
+    """The user's custom preprocessor must not be mutated by Poniard."""
+    from sklearn.pipeline import Pipeline
+    from sklearn.preprocessing import StandardScaler
+
+    custom = Pipeline([("scaler", StandardScaler())])
+    X = pd.DataFrame(np.random.normal(size=(30, 3)), columns=list("abc"))
+    y = np.random.choice([0, 1], size=30)
+
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression()], custom_preprocessor=custom, cv=2, random_state=0
+    )
+    clf.setup(X, y)
+    assert clf.preprocessor is not custom
+    assert len(custom.steps) == 1
+
+    clf.add_preprocessing_step(("s2", StandardScaler()))
+    assert len(custom.steps) == 1

--- a/tests/test_side_effects.py
+++ b/tests/test_side_effects.py
@@ -172,9 +172,7 @@ def test_custom_sklearn_preprocessor_outputs_pandas_without_global_set_config():
         X.iloc[0, 0] = np.nan
         y = np.zeros(n, dtype=int)
         y[::2] = 1
-        custom = Pipeline(
-            [("imputer", SimpleImputer()), ("scaler", StandardScaler())]
-        )
+        custom = Pipeline([("imputer", SimpleImputer()), ("scaler", StandardScaler())])
         clf = PoniardClassifier(
             estimators=[LogisticRegression()],
             custom_preprocessor=custom,

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,109 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.15.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/060ce69008ac97bbc01b1411b3e55b61f6f015659400b46749b662107831/coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d", size = 221284, upload-time = "2026-07-15T18:53:29.52Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a3/d936e8b53edd9684100a6aefaf3fcabaa54728fe33324436c8d279c047aa/coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846", size = 221799, upload-time = "2026-07-15T18:53:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a3/ca234b06aec7ee28226f11d39a696b4481fe5eddfce8e03bf39979bb8ffb/coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf", size = 248544, upload-time = "2026-07-15T18:53:33.212Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/dda79527bb7573ba91828b2fb91b3105d87378d6a2749ca0c0924ce0addd/coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376", size = 250374, upload-time = "2026-07-15T18:53:34.683Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c6/c33755a34572f81f49a8c0cdf6b622f35ccb3238b136e1909daf0cdd4319/coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd", size = 252239, upload-time = "2026-07-15T18:53:36.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6f/dc341741b375be53a5baeee5b4bf0f0e525d38caed428f7932d23bb7bcb1/coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb", size = 254150, upload-time = "2026-07-15T18:53:37.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8d/966a18a5b195cb4e77b14c53f5f3dce22b5da05e6de7fafd1e08f2d2067a/coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1", size = 249234, upload-time = "2026-07-15T18:53:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/8b2e367496ab48484d48e79984fec76cdc1b7cb5d3a00ee799a5602e3ec9/coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9", size = 250276, upload-time = "2026-07-15T18:53:41.027Z" },
+    { url = "https://files.pythonhosted.org/packages/63/92/1199318a200eb6c8c6ce0192c892c8710ac791abbe0f35099294620bbfda/coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a", size = 248283, upload-time = "2026-07-15T18:53:42.557Z" },
+    { url = "https://files.pythonhosted.org/packages/56/da/be284a55c5619bda891a89c27dfd59324a2c6a14d755cf6aac6960ceebeb/coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287", size = 252093, upload-time = "2026-07-15T18:53:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/53/ee112da833ddd77b73c6d781a98029b45b584b136615b4900ed0569f887e/coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89", size = 248552, upload-time = "2026-07-15T18:53:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6a/802cfc802e9113494c80bf3f284cd4d72faeb1f24e244f61046af364f2ca/coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88", size = 249154, upload-time = "2026-07-15T18:53:47.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/65/529808e91d651147edae408fd9e894abc3b8cad7f3e594bbc36719a3e13a/coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443", size = 223334, upload-time = "2026-07-15T18:53:48.768Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0f/0e1829d7001130876dfbc0b4e1c737ea7c155b809e3e4a98a0aa268e2369/coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629", size = 223959, upload-time = "2026-07-15T18:53:50.429Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -369,12 +472,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "plotly" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
 plot = [
     { name = "plotly" },
 ]
@@ -384,6 +481,7 @@ dev = [
     { name = "poniard", extra = ["plot"] },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
 ]
 
@@ -393,21 +491,18 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "plotly", marker = "extra == 'plot'" },
-    { name = "poniard", extras = ["plot"], marker = "extra == 'dev'" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "tqdm" },
 ]
-provides-extras = ["plot", "dev"]
+provides-extras = ["plot"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "poniard", extras = ["plot"] },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff", specifier = ">=0.16.0" },
 ]
 
@@ -452,6 +547,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Phase 4 of the tech debt roadmap (TECH_DEBT.md)

Stacked on #56 (Phase 3). Review order: #53 → #54 → #55 → #56 → **#57**.
220 tests passing, coverage gate green (88.47% ≥ 85%).

Covers P1-A4 (satellite protocol), P1-A5 (clone-before-configure), P1-A6
(uniform mutator invalidation) and the P2 smell cleanup.

### A4 — document the internal estimator contract
- New `EstimatorView` `Protocol` in `core.py` declares the estimator surface
  that plotting and error analysis are allowed to use. `PoniardPlotFactory`
  and `ErrorAnalyzer` are now typed against it (TYPE_CHECKING only — no
  runtime cost). Reaching past this surface is now a documented defect.
- Dummy detection consolidated onto `_dummy_names()`: `time_quality_scatter`
  and `ErrorAnalyzer.from_poniard` no longer reimplement it with their own
  `isinstance(pipeline._final_estimator, (DummyClassifier, DummyRegressor))`.

### A5 — stop mutating objects the user owns
- `_make_pipeline` clones and configures the estimator; the user's estimator
  instances are no longer modified by `_pass_instance_attrs` (reproducibility
  is preserved on the clone).
- `_build_cv` clones the user's CV splitter before applying
  random_state/verbose. Note: CV splitters aren't estimators in this sklearn,
  so this uses `clone(cv, safe=False)` (deepcopy fallback).
- `_configure` clones a custom preprocessor; `add_preprocessing_step` works
  on a clone before inserting steps — a user-supplied `Pipeline` is never
  mutated in place.
- 3 new tests in `test_side_effects.py` assert non-mutation.

### P2 smell cleanup
- `_generate_estimator_name`: dropped dead `all_estimators` param.
- `_init_params`: explicit parameter dicts (core, preprocessor, ErrorAnalyzer)
  instead of fragile `locals()` capture.
- `_predict`: replaced blanket `except AttributeError` with an `hasattr`
  pre-check.
- `roc_curve`: validates binary target (`nunique == 2`), not just `ndim > 1`
  (1-D multiclass previously slipped through).
- `error_lift_bars`: removed dead `estimator_names` param; docstring now
  matches behavior (raises when `lift_by_target` is None).
- Extracted shared `coerce_input` (polars/array coercion, was copy-pasted in
  `core._configure` and `PoniardPreprocessor._setup_data`) and
  `infer_feature_types` (feature-type inference, was duplicated). 
  `ErrorAnalyzer.analyze_features` no longer builds a throwaway
  `PoniardPreprocessor(task="placeholder")` to infer types.
- `from typing import Sequence` → `collections.abc` (3 files); dropped dead
  `if TYPE_CHECKING: pass`; hoisted the `sklearn.dummy` import out of
  `from_poniard`.

### A6 — uniform mutator invalidation (largely landed in Phase 0/1)
Rebuild paths go through `_build_pipelines` (resets fitted tracking);
`remove_estimators` clears fitted tracking and both stores; the
`setup() → mutate → fit()` contract is unchanged and documented.

### Verification
- `uv run ruff check` + `ruff format --check` — clean
- `uv run pytest --cov=poniard --cov-fail-under=85` — **220 passed, 88.47%**