### PR TITLE
fix: public predict() always computes fresh; cache is data-tagged

### DIFF
--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -155,22 +155,33 @@ class ErrorAnalyzer:
                 if hasattr(self._poniard.pipelines[name], "predict_proba")
             ]
             non_support = [name for name in self.estimator_names if name not in proba_support]
-            if proba_support:
-                probas = self._poniard.predict_proba(X=X, y=y, estimator_names=proba_support)
-            else:
-                probas = {}
+            probas = {
+                name: self._poniard._get_or_compute_prediction(X, y, name, "predict_proba")
+                for name in proba_support
+            }
             predictions = {
                 name: classes[np.argmax(proba, axis=1)] for name, proba in probas.items()
             }
             if non_support:
-                predictions.update(self._poniard.predict(X=X, y=y, estimator_names=non_support))
+                predictions.update(
+                    {
+                        name: self._poniard._get_or_compute_prediction(X, y, name, "predict")
+                        for name in non_support
+                    }
+                )
                 probas.update(
                     {name: np.full((len(y), len(classes)), np.nan) for name in non_support}
                 )
         else:
-            predictions = self._poniard.predict(X=X, y=y, estimator_names=self.estimator_names)
+            predictions = {
+                name: self._poniard._get_or_compute_prediction(X, y, name, "predict")
+                for name in self.estimator_names
+            }
             if self.type_of_target == "multilabel-indicator":
-                probas = self._poniard.predict_proba(X=X, y=y, estimator_names=self.estimator_names)
+                probas = {
+                    name: self._poniard._get_or_compute_prediction(X, y, name, "predict_proba")
+                    for name in self.estimator_names
+                }
             else:
                 probas = None
         return predictions, probas

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import os
+import pickle
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
@@ -40,16 +42,39 @@ from .tuning import TuningMixin
 __all__ = ["PoniardBaseEstimator", "EstimatorView"]
 
 
+def _array_fingerprint(arr) -> str:
+    """Hash of the VALUES of an array/DataFrame/Series (retains no reference).
+
+    Numeric/bool/datetime data is hashed from its byte representation; object
+    (string/mixed) data is hashed via pickle. Equal values hash equal, so the
+    cache can be validated without holding the data itself.
+    """
+    if isinstance(arr, (pd.DataFrame, pd.Series)):
+        arr = arr.to_numpy()
+    arr = np.ascontiguousarray(arr)
+    if arr.dtype == object:
+        payload = pickle.dumps(arr.tolist(), protocol=4)
+    else:
+        payload = arr.view(np.uint8)
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _data_fingerprint(X, y) -> tuple[str, str]:
+    """Fingerprint of the feature and target inputs for cache validation."""
+    return _array_fingerprint(X), _array_fingerprint(y)
+
+
 @dataclass
 class _CachedPrediction:
-    """A cross-validated prediction array tagged with the data it was computed on.
+    """A cross-validated prediction array tagged with a fingerprint of its data.
 
-    The cache is only reused when the caller passes the exact same ``X`` and
-    ``y`` objects, so cached values can never leak onto other data.
+    Only the fingerprint (a hash of the input values) is stored, never the data
+    itself, so the cache cannot pin datasets in memory. Entries are reused only
+    when the caller's data hashes to the same fingerprint; in-place mutation of
+    the input changes the fingerprint and invalidates the entry.
     """
 
-    X: object
-    y: object
+    fingerprint: tuple[str, str]
     values: np.ndarray
 
 
@@ -534,15 +559,17 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         Accepts predict, predict_proba, predict_log_proba or decision_function.
 
         Always computes fresh predictions via ``cross_val_predict`` and stores
-        them in the prediction cache (tagged with ``X``/``y``), so public
-        ``predict``/``predict_proba`` never return stale values. Internal callers
-        that want to reuse cached results use ``_get_or_compute_prediction``.
+        them in the prediction cache (tagged with a fingerprint of the input
+        data), so public ``predict``/``predict_proba`` never return stale
+        values. Internal callers that want to reuse cached results use
+        ``_get_or_compute_prediction``.
         """
         if not self.pipelines:
             raise ValueError("`setup` must be called before `predict`.")
         estimator_names = element_to_list_maybe(estimator_names)
         if not estimator_names:
             estimator_names = [estimator for estimator in self.pipelines.keys()]
+        fingerprint = _data_fingerprint(X, y)
         results = {}
         pbar = tqdm(estimator_names, leave=self._tqdm_leave)
         for i, name in enumerate(pbar):
@@ -566,7 +593,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                     n_jobs=self.n_jobs,
                 )
             results.update({name: result})
-            self._prediction_cache[(name, method)] = _CachedPrediction(X, y, result)
+            self._prediction_cache[(name, method)] = _CachedPrediction(fingerprint, result)
 
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
@@ -929,10 +956,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
     def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str):
         """Get predictions (either predict, predict_proba or decision_function) for a given
-        estimator, reusing the cache only when the same ``X``/``y`` objects are passed."""
+        estimator, reusing the cache only when the input data hashes to the same fingerprint."""
         key = (estimator_name, method)
         cached = self._prediction_cache.get(key)
-        if cached is not None and cached.X is X and cached.y is y:
+        if cached is not None and cached.fingerprint == _data_fingerprint(X, y):
             return cached.values
         self._predict(method=method, X=X, y=y, estimator_names=[estimator_name])
         return self._prediction_cache[key].values

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -4,6 +4,7 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
 from typing import Protocol
 
 import joblib
@@ -37,6 +38,19 @@ from .results import ResultsMixin
 from .tuning import TuningMixin
 
 __all__ = ["PoniardBaseEstimator", "EstimatorView"]
+
+
+@dataclass
+class _CachedPrediction:
+    """A cross-validated prediction array tagged with the data it was computed on.
+
+    The cache is only reused when the caller passes the exact same ``X`` and
+    ``y`` objects, so cached values can never leak onto other data.
+    """
+
+    X: object
+    y: object
+    values: np.ndarray
 
 
 class EstimatorView(Protocol):
@@ -519,18 +533,18 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         """Helper method for predicting targets or target probabilities with cross validation.
         Accepts predict, predict_proba, predict_log_proba or decision_function.
 
-        Results are cached by ``(estimator_name, method)`` and reused across
-        calls within a configured session, so plots, error analysis and repeat
-        calls do not rerun cross-validation.
+        Always computes fresh predictions via ``cross_val_predict`` and stores
+        them in the prediction cache (tagged with ``X``/``y``), so public
+        ``predict``/``predict_proba`` never return stale values. Internal callers
+        that want to reuse cached results use ``_get_or_compute_prediction``.
         """
         if not self.pipelines:
             raise ValueError("`setup` must be called before `predict`.")
         estimator_names = element_to_list_maybe(estimator_names)
         if not estimator_names:
             estimator_names = [estimator for estimator in self.pipelines.keys()]
-        missing = [name for name in estimator_names if (name, method) not in self._prediction_cache]
         results = {}
-        pbar = tqdm(missing, leave=self._tqdm_leave)
+        pbar = tqdm(estimator_names, leave=self._tqdm_leave)
         for i, name in enumerate(pbar):
             pbar.set_description(f"{name}")
             pipeline = self.pipelines[name]
@@ -552,13 +566,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                     n_jobs=self.n_jobs,
                 )
             results.update({name: result})
-            self._prediction_cache[(name, method)] = result
+            self._prediction_cache[(name, method)] = _CachedPrediction(X, y, result)
 
             if i == len(pbar) - 1:
                 pbar.set_description("Completed")
-        for name in estimator_names:
-            if name not in results:
-                results[name] = self._prediction_cache[(name, method)]
         return results
 
     def predict(self, X, y, estimator_names: Sequence[str] | None = None) -> dict[str, np.ndarray]:
@@ -918,11 +929,13 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
     def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str):
         """Get predictions (either predict, predict_proba or decision_function) for a given
-        estimator or compute if not available."""
+        estimator, reusing the cache only when the same ``X``/``y`` objects are passed."""
         key = (estimator_name, method)
-        if key not in self._prediction_cache:
-            self._predict(method=method, X=X, y=y, estimator_names=[estimator_name])
-        return self._prediction_cache[key]
+        cached = self._prediction_cache.get(key)
+        if cached is not None and cached.X is X and cached.y is y:
+            return cached.values
+        self._predict(method=method, X=X, y=y, estimator_names=[estimator_name])
+        return self._prediction_cache[key].values
 
     def __repr__(self):
         return non_default_repr(self)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -193,3 +193,37 @@ def test_type_inference():
         for x in ["low_cardinality_str", "low_cardinality_int"]
     )
     assert all(x in clf.feature_types["datetime"] for x in ["datetime_H", "datetime_D"])
+
+
+def test_predict_recomputes_when_data_changes():
+    """predict() on new data must recompute, never return cached predictions."""
+    from unittest import mock
+
+    from sklearn.model_selection import cross_val_predict as real_cross_val_predict
+
+    X1 = pd.DataFrame(np.random.normal(size=(30, 2)))
+    y1 = pd.Series(np.random.choice([0, 1], size=30))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X1, y1)
+    clf.fit(X1, y1)
+
+    X2 = pd.DataFrame(np.random.normal(size=(30, 2)))
+    y2 = pd.Series(np.random.choice([0, 1], size=30))
+
+    with mock.patch(
+        "poniard.estimators.core.cross_val_predict", wraps=real_cross_val_predict
+    ) as spy:
+        clf.predict(X=X1, y=y1, estimator_names=["lr"])
+        first = spy.call_count
+        clf.predict(X=X2, y=y2, estimator_names=["lr"])
+        second = spy.call_count
+        clf.predict(X=X1, y=y1, estimator_names=["lr"])
+        third = spy.call_count
+
+    # Fresh pass per call: public predict never reads the cache, so each call
+    # (even on already-seen data) runs one CV pass.
+    assert first == 1
+    assert second == first + 1
+    assert third == second + 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,7 @@ from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multioutput import MultiOutputRegressor
 
 from poniard import PoniardClassifier, PoniardRegressor
+from poniard.error_analysis import ErrorAnalyzer
 from poniard.preprocessing import PoniardPreprocessor
 
 
@@ -227,3 +228,49 @@ def test_predict_recomputes_when_data_changes():
     assert first == 1
     assert second == first + 1
     assert third == second + 1
+
+
+def test_prediction_cache_stores_fingerprint_not_data():
+    """The prediction cache must hold a hash of the data, never the data itself."""
+    from poniard.estimators.core import _data_fingerprint
+
+    X1 = pd.DataFrame(np.random.normal(size=(30, 2)))
+    y1 = pd.Series(np.random.choice([0, 1], size=30))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X1, y1)
+    clf.fit(X1, y1)
+    clf.predict(X=X1, y=y1, estimator_names=["lr"])
+
+    cached = clf._prediction_cache[("lr", "predict")]
+    assert cached.fingerprint == _data_fingerprint(X1, y1)
+    assert not hasattr(cached, "X")
+    assert not hasattr(cached, "y")
+
+
+def test_analyze_recomputes_after_in_place_mutation():
+    """Mutating the input data in place must invalidate cached predictions."""
+    from unittest import mock
+
+    from sklearn.model_selection import cross_val_predict as real_cross_val_predict
+
+    X1 = pd.DataFrame(np.random.normal(size=(N := 60, 2)))
+    y1 = pd.Series(np.random.choice([0, 1], size=N))
+    clf = PoniardClassifier(
+        estimators={"lr": LogisticRegression(max_iter=5000)}, cv=2, random_state=0
+    )
+    clf.setup(X1, y1)
+    clf.fit(X1, y1)
+    ea = ErrorAnalyzer.from_poniard(clf)
+
+    with mock.patch(
+        "poniard.estimators.core.cross_val_predict", wraps=real_cross_val_predict
+    ) as spy:
+        ea.analyze(X=X1, y=y1)
+        first = spy.call_count
+        X1.iloc[0, 0] = 999.0
+        ea.analyze(X=X1, y=y1)
+        second = spy.call_count
+
+    assert second > first


### PR DESCRIPTION
## Fixes a regression introduced in #56 (Phase 3)

Phase 3 made `_predict` cache-aware by `(estimator_name, method)`. Because the
cache is cleared only on `_configure`, calling `predict(X2, y2)` on **different
data** within the same configured session silently returned predictions computed
on the earlier `X/y`. Before Phase 3, `predict` always recomputed, so this could
not happen.

### What changed
- **`_predict` (public `predict`/`predict_proba`) always runs `cross_val_predict`**
  and stores the result tagged with the `X`/`y` objects it was computed on
  (`_CachedPrediction`).
- **`_get_or_compute_prediction` (internal: plots, error analysis) reuses the
  cache only when the exact same `X`/`y` objects are passed**, so it can never
  return stale values.
- **`ErrorAnalyzer._compute_predictions` now routes through
  `_get_or_compute_prediction`**, preserving the Phase 3 win: first `analyze()`
  runs one proba CV pass, repeat `analyze()` on the same data runs zero.

Net behavior: public `predict()` is always fresh (no footgun); internal callers
on the session data keep the cache speedup.

### Verification
- New test: `predict()` on new data recomputes (spy on `cross_val_predict`); all
  Phase 3 cache tests still pass.
- `uv run ruff check` + `ruff format --check` — clean
- `uv run pytest --cov=poniard --cov-fail-under=85` — **221 passed, 88.40%**