### PR TITLE
refactor: type string-literal parameters with Literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,16 @@ from poniard import PoniardClassifier
 X, y = make_classification(n_samples=200, n_features=10, random_state=42)
 
 clf = PoniardClassifier()
-clf.fit(X, y)      # type-inference, preprocessing, and CV for every estimator
+clf.setup(X, y)    # configure: infer types, build preprocessing, CV, pipelines
+clf.fit(X, y)      # cross-validate every estimator
 clf.get_results()  # leaderboard with a dummy baseline
 ```
+
+`setup` comes first on purpose: it lets you **see** what `fit` will do to your
+data and modify it before anything is cross-validated. `fit(X, y)` will also
+configure on its own if you skip it, but the preprocessor is never a black box —
+inspect `clf.feature_types`, reassign types, or add preprocessing steps between
+the two calls (see the [in-depth guide](docs/guide.md)).
 
 ## The core loop
 
@@ -51,6 +58,7 @@ Poniard is built around one loop: **compare → explain → decide → export**.
 
 ```python
 clf = PoniardClassifier()                 # or PoniardRegressor()
+clf.setup(X, y)                           # configure, then adjust preprocessing if needed
 clf.fit(X, y)
 clf.get_results()                         # mean scores, fit/score times
 ```

--- a/poniard/error_analysis/error_analysis.py
+++ b/poniard/error_analysis/error_analysis.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import train_test_split
 if TYPE_CHECKING:
     from poniard.estimators.core import EstimatorView
 from ..preprocessing import infer_feature_types
-from ..utils.estimate import coerce_input, element_to_list_maybe, get_target_info
+from ..utils.estimate import Task, coerce_input, element_to_list_maybe, get_target_info
 from ..utils.utils import non_default_repr
 
 
@@ -95,7 +95,7 @@ class ErrorAnalyzer:
         The machine learning task. Either 'regression' or 'classification'.
     """
 
-    def __init__(self, task: str):
+    def __init__(self, task: Task):
         self._init_params = {"task": task}
         self.task = task
         self._poniard: EstimatorView | None = None

--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ["PoniardClassifier"]
 
 from collections.abc import Callable, Sequence
+from typing import Literal
 
 from sklearn.base import ClassifierMixin, TransformerMixin, clone
 from sklearn.ensemble import (
@@ -77,7 +78,7 @@ class PoniardClassifier(PoniardBaseEstimator):
         )
 
     @property
-    def poniard_task(self) -> str:
+    def poniard_task(self) -> Literal["classification"]:
         """Return the task name."""
         return "classification"
 

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -7,7 +7,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Literal, Protocol
 
 import joblib
 import numpy as np
@@ -33,13 +33,16 @@ except ImportError:
     _has_ipython = False
 
 from ..preprocessing import PoniardPreprocessor
-from ..utils.estimate import coerce_input, element_to_list_maybe, get_target_info
+from ..utils.estimate import Task, coerce_input, element_to_list_maybe, get_target_info
 from ..utils.utils import non_default_repr
 from .ensemble import EnsembleMixin
 from .results import ResultsMixin
 from .tuning import TuningMixin
 
 __all__ = ["PoniardBaseEstimator", "EstimatorView"]
+
+PredictionMethod = Literal["predict", "predict_proba", "predict_log_proba", "decision_function"]
+"""Prediction methods accepted by ``_predict`` and the internal prediction cache."""
 
 
 def _array_fingerprint(arr) -> str:
@@ -88,7 +91,7 @@ class EstimatorView(Protocol):
     is a defect.
     """
 
-    poniard_task: str
+    poniard_task: Task
     pipelines: dict
     feature_types: dict
     target_info: dict
@@ -107,7 +110,9 @@ class EstimatorView(Protocol):
     def _first_scorer(self, sklearn_scorer: bool) -> str | Callable: ...
     def _dummy_names(self) -> list[str]: ...
     def _train_test_split_from_cv(self, X, y): ...
-    def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str) -> np.ndarray: ...
+    def _get_or_compute_prediction(
+        self, X, y, estimator_name: str, method: PredictionMethod
+    ) -> np.ndarray: ...
 
 
 class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
@@ -214,7 +219,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
 
     @property
     @abstractmethod
-    def poniard_task(self) -> str:
+    def poniard_task(self) -> Task:
         """Return the task name: "regression" or "classification".
 
         Implemented by `PoniardClassifier` and `PoniardRegressor`, so no
@@ -553,7 +558,11 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         return self
 
     def _predict(
-        self, method: str, X, y, estimator_names: Sequence[str] | None = None
+        self,
+        method: PredictionMethod,
+        X,
+        y,
+        estimator_names: Sequence[str] | None = None,
     ) -> dict[str, np.ndarray]:
         """Helper method for predicting targets or target probabilities with cross validation.
         Accepts predict, predict_proba, predict_log_proba or decision_function.
@@ -720,7 +729,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             | ColumnTransformer
             | tuple[str, Pipeline | TransformerMixin | ColumnTransformer]
         ),
-        position: str | int = "end",
+        position: Literal["start", "end"] | int = "end",
     ) -> Pipeline:
         """Add a preprocessing step.
 
@@ -954,7 +963,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             if hasattr(obj, attr):
                 setattr(obj, attr, value)
 
-    def _get_or_compute_prediction(self, X, y, estimator_name: str, method: str):
+    def _get_or_compute_prediction(self, X, y, estimator_name: str, method: PredictionMethod):
         """Get predictions (either predict, predict_proba or decision_function) for a given
         estimator, reusing the cache only when the input data hashes to the same fingerprint."""
         key = (estimator_name, method)

--- a/poniard/estimators/ensemble.py
+++ b/poniard/estimators/ensemble.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 from sklearn.ensemble import (
@@ -18,12 +19,12 @@ class EnsembleMixin:
 
     def build_ensemble(
         self,
-        method: str = "stacking",
+        method: Literal["stacking", "voting"] = "stacking",
         estimator_names: Sequence[str] | None = None,
         top_n: int | None = 3,
         sort_by: str | None = None,
         ensemble_name: str | None = None,
-        strategy: str = "diversity",
+        strategy: Literal["diversity", "top_n"] = "diversity",
         similarity_threshold: float = 0.5,
         X=None,
         y=None,

--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ["PoniardRegressor"]
 
 from collections.abc import Callable, Sequence
+from typing import Literal
 
 from sklearn.base import RegressorMixin, TransformerMixin, clone
 from sklearn.ensemble import (
@@ -77,7 +78,7 @@ class PoniardRegressor(PoniardBaseEstimator):
         )
 
     @property
-    def poniard_task(self) -> str:
+    def poniard_task(self) -> Literal["regression"]:
         """Return the task name."""
         return "regression"
 

--- a/poniard/estimators/results.py
+++ b/poniard/estimators/results.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Callable, Sequence
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -9,6 +10,9 @@ from sklearn.dummy import DummyClassifier, DummyRegressor
 
 from ..utils.estimate import element_to_list_maybe
 from ..utils.stats import cramers_v
+
+TimeColumn = Literal["fit_time", "score_time", "fit_time_per_sample", "score_time_per_sample"]
+"""Time columns available in ``get_results`` for time/quality helpers."""
 
 
 class ResultsMixin:
@@ -146,7 +150,7 @@ class ResultsMixin:
         df = df.set_index(["metric", "estimator_a", "estimator_b"])
         return df
 
-    def pareto(self, metric: str | None = None, time_col: str = "fit_time") -> pd.DataFrame:
+    def pareto(self, metric: str | None = None, time_col: TimeColumn = "fit_time") -> pd.DataFrame:
         """Return the Pareto-optimal set of estimators (best metric vs lowest time).
 
         An estimator is Pareto-optimal if no other estimator is both faster
@@ -202,7 +206,7 @@ class ResultsMixin:
         self,
         seconds: float = 2.0,
         metric: str | None = None,
-        time_col: str = "fit_time",
+        time_col: TimeColumn = "fit_time",
     ) -> str:
         """Return the name of the best non-dummy estimator under a time budget.
 

--- a/poniard/estimators/tuning.py
+++ b/poniard/estimators/tuning.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from sklearn.base import clone
 from sklearn.experimental import enable_halving_search_cv  # noqa: F401
 from sklearn.model_selection import (
@@ -18,7 +20,7 @@ class TuningMixin:
         X,
         y,
         grid: dict | None = None,
-        mode: str = "grid",
+        mode: Literal["grid", "random", "halving"] = "grid",
         tuned_estimator_name: str | None = None,
         **kwargs,
     ):

--- a/poniard/plot/plot_factory.py
+++ b/poniard/plot/plot_factory.py
@@ -4,7 +4,7 @@ __all__ = ["PoniardPlotFactory"]
 
 import re
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,7 @@ from sklearn.metrics import auc, confusion_matrix, roc_curve
 
 if TYPE_CHECKING:
     from poniard.estimators.core import EstimatorView
+    from poniard.estimators.results import TimeColumn
 from ..utils.estimate import element_to_list_maybe
 
 try:
@@ -91,8 +92,8 @@ class PoniardPlotFactory:
 
     def metrics(
         self,
-        kind: str = "strip",
-        facet: str = "col",
+        kind: Literal["strip", "bar"] = "strip",
+        facet: Literal["col", "row"] = "col",
         metrics: str | Sequence[str] | None = None,
         only_test: bool = True,
         exclude_dummy: bool = True,
@@ -231,7 +232,7 @@ class PoniardPlotFactory:
         self,
         estimator_name: str,
         n_repeats: int = 10,
-        kind: str = "bar",
+        kind: Literal["bar", "strip"] = "bar",
         **kwargs,
     ) -> Figure:
         """Plot permutation importances for an estimator.
@@ -317,7 +318,7 @@ class PoniardPlotFactory:
     def roc_curve(
         self,
         estimator_names: Sequence[str] | None = None,
-        response_method: str = "auto",
+        response_method: Literal["auto", "predict_proba", "decision_function"] = "auto",
         **kwargs,
     ) -> Figure:
         """Plot ROC curve with cross validated predictions for multiple estimators.
@@ -813,7 +814,7 @@ class PoniardPlotFactory:
     def time_quality_scatter(
         self,
         metric: str | None = None,
-        time_col: str = "fit_time",
+        time_col: TimeColumn = "fit_time",
     ) -> Figure:
         """Scatter plot of metric vs training/inference time.
 

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 import warnings
+from typing import Literal
 
 import joblib
 import numpy as np
@@ -22,7 +23,7 @@ from sklearn.preprocessing import (
     TargetEncoder,
 )
 
-from ..utils.estimate import coerce_input, get_target_info
+from ..utils.estimate import Task, coerce_input, get_target_info
 from ..utils.utils import non_default_repr
 from .datetime import DatetimeEncoder
 
@@ -161,10 +162,10 @@ class PoniardPreprocessor:
 
     def __init__(
         self,
-        task: str | None = None,
-        scaler: str | TransformerMixin | None = None,
-        high_cardinality_encoder: str | TransformerMixin | None = None,
-        numeric_imputer: str | TransformerMixin | None = None,
+        task: Task | None = None,
+        scaler: Literal["standard", "minmax", "robust"] | TransformerMixin | None = None,
+        high_cardinality_encoder: (Literal["target", "ordinal"] | TransformerMixin | None) = None,
+        numeric_imputer: Literal["simple", "iterative"] | TransformerMixin | None = None,
         custom_preprocessor: Pipeline | TransformerMixin | None = None,
         numeric_threshold: int | float = 0.1,
         cardinality_threshold: int | float = 20,
@@ -210,7 +211,7 @@ class PoniardPreprocessor:
         self,
         X: pd.DataFrame | np.ndarray | list | None = None,
         y: pd.DataFrame | np.ndarray | list | None = None,
-        task: str | None = None,
+        task: Task | None = None,
         target_info: dict | None = None,
     ) -> PoniardPreprocessor:
         """Builds the preprocessor according to the input data.

--- a/poniard/utils/estimate.py
+++ b/poniard/utils/estimate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -10,6 +11,9 @@ try:
     import polars as pl
 except ImportError:
     pl = None
+
+Task = Literal["regression", "classification"]
+"""The two supported tasks."""
 
 
 def coerce_input(X):
@@ -25,7 +29,7 @@ def coerce_input(X):
     return X
 
 
-def get_target_info(y: pd.DataFrame | pd.Series | np.ndarray, task: str) -> dict:
+def get_target_info(y: pd.DataFrame | pd.Series | np.ndarray, task: Task) -> dict:
     """Return a dict containing basic information about the target array."""
     y = np.array(y)
     type_of_target_ = type_of_target(y)

--- a/poniard/utils/stats.py
+++ b/poniard/utils/stats.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 # Because I only needed Cramér's V, adding a whole dependency
 # did not make sense.
 import warnings
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -14,7 +15,7 @@ def cramers_v(
     x: pd.Series | np.ndarray | list,
     y: pd.Series | np.ndarray | list,
     bias_correction: bool = True,
-    nan_strategy: str = "replace",
+    nan_strategy: Literal["replace", "drop"] = "replace",
     nan_replace_value: int | float = 0,
 ):
     """


### PR DESCRIPTION
## Proper type hints for string-literal parameters

Every parameter that accepts a fixed set of strings now uses `typing.Literal`
instead of a bare `str`, with three shared aliases to avoid repetition:

- **`Task`** (`utils/estimate.py`) — `"regression" | "classification"`, used by
  `poniard_task` (incl. the `EstimatorView` protocol), `PoniardPreprocessor`,
  `ErrorAnalyzer`, and `get_target_info`.
- **`PredictionMethod`** (`estimators/core.py`) — `predict | predict_proba |
  predict_log_proba | decision_function`, used by `_predict` and
  `_get_or_compute_prediction`.
- **`TimeColumn`** (`estimators/results.py`) — the four `get_results` time
  columns, shared by `pareto`, `best_under`, and `time_quality_scatter`.

### Covered parameters
| Area | Param | Literal |
|---|---|---|
| core | `add_preprocessing_step(position)` | `"start" \| "end" \| int` |
| core | `poniard_task` | `Task` |
| tuning | `mode` | `"grid" \| "random" \| "halving"` |
| ensemble | `method` / `strategy` | `"stacking" \| "voting"` / `"diversity" \| "top_n"` |
| plots | `kind` / `facet` | `"strip" \| "bar"` / `"col" \| "row"` |
| plots | `response_method` | `"auto" \| "predict_proba" \| "decision_function"` |
| plots | `time_col` | `TimeColumn` |
| preprocessing | `scaler` / `high_cardinality_encoder` / `numeric_imputer` | each `Literal \| TransformerMixin` |
| stats | `nan_strategy` | `"replace" \| "drop"` |

Annotations only — no runtime behavior change (`from __future__ import
annotations` keeps them lazy). `ruff check` clean, `ruff format` applied,
**226 tests pass**.