### PR TITLE
fix: P0 preprocessing correctness issues

### DIFF
--- a/docs/preprocessing-improvements.md
+++ b/docs/preprocessing-improvements.md
@@ -1,0 +1,174 @@
+# Preprocessing improvements
+
+Proposed improvements for `poniard/preprocessing/`, sorted by priority.
+P0 items change observable behavior (some are latent bugs); P1 fixes input
+parity; P2 adds opt-in modeling quality; P3 is hygiene.
+
+Explicitly out of scope (decided):
+
+- ID-like column detection (uniqueness is not a reliable signal, e.g. GDP-like floats).
+- Coercing object columns to datetime (user's responsibility).
+- Sparse one-hot output (dense OHE on low-cardinality features is intentional).
+
+---
+
+## P0 — Correctness / consistency
+
+### 1. Stable output feature names regardless of type composition
+
+**Problem.** `PoniardPreprocessor.build()` (`core.py:314-317`) strips empty
+transformers and, when only one remains, replaces the whole `ColumnTransformer`
+with the inner transformer. But with ≥2 feature types, `ColumnTransformer`
+defaults to `verbose_feature_names_out=True`, so outputs are prefixed
+(`numeric_preprocessor__age`); with a single type they are unprefixed (`age`).
+Adding one categorical column silently renames every downstream feature,
+breaking feature-importance comparisons, SHAP, and any name-keyed consumer.
+
+**Fix.**
+
+- Set `verbose_feature_names_out=False` on every `ColumnTransformer` built in
+  `build()`.
+- Stop unwrapping single-transformer `ColumnTransformer`s (or build the
+  transformer list conditionally *before* constructing the
+  `ColumnTransformer`, instead of mutating `.transformers` after the fact).
+- Add a test asserting identical feature names for the same columns whether or
+  not other feature types are present.
+
+### 2. Datetime features bypass scaling (and use mode imputation)
+
+**Problem.** The datetime pipeline is `DatetimeEncoder →
+SimpleImputer(most_frequent)` (`core.py:404-412`). Encoded outputs mix scales
+(year ≈ 2020, dayofyear 1–366, month 1–12) and reach estimators unscaled,
+while numeric features are scaled — inconsistent for regularized and
+distance-based models. Mode imputation is also statistically odd for what are
+effectively numeric features.
+
+**Fix.** Append the configured scaler (and use `median` imputation) to the
+datetime pipeline, or route encoded datetime features through the numeric
+pipeline. Add a test asserting datetime-derived features are scaled.
+
+### 3. Dead `custom_preprocessor` parameter
+
+**Problem.** `PoniardPreprocessor.__init__` accepts `custom_preprocessor` and
+stores it in `_init_params` (`core.py:169, 183`) but never uses it — the
+estimator layer handles custom preprocessors itself.
+
+**Fix.** Remove it from the signature and `_init_params`, or actually honor it
+inside `build()`. Prefer removal (single responsibility).
+
+### 4. `build()` without data raises a confusing error
+
+**Problem.** Calling `build()` before any data is set surfaces
+`NotImplementedError("Both X and y need to be passed to _setup_data.")`
+(`core.py:339`), referencing a private method.
+
+**Fix.** Raise `ValueError("X and y must be passed to build() (or set by a
+previous build() call).")`.
+
+### 5. Implicit external-mutation contract for `feature_types`
+
+**Problem.** `estimators/core.py:718-719` sets
+`_poniard_preprocessor.feature_types` directly and calls `build()`; `build()`
+then relies on `try/except AttributeError` (`core.py:241-247`) to skip
+inference. `inferred_types_df` is only produced as a side effect of
+`_infer_dtypes()`, so the two attributes can drift out of sync.
+
+**Fix.** Make it explicit: add a `feature_types` parameter to `build()` (or a
+property setter) that also refreshes `inferred_types_df`, and have
+`estimators/core.py` use it instead of poking the attribute.
+
+---
+
+## P1 — Type inference parity
+
+### 6. Unify the pandas/numpy paths in `infer_feature_types`
+
+**Problem.** The two branches (`core.py:79-116`) duplicate the logic and
+disagree on edge cases:
+
+- pandas `nunique()` ignores NaN; `np.unique` counts it — the same column can
+  classify differently depending on the input container.
+- Booleans: `pd.api.types.is_numeric_dtype(bool)` is True, while
+  `np.issubdtype(bool, np.number)` is False, so they take different paths.
+
+**Fix.** Coerce array input to a DataFrame once (reuse `coerce_input`) and keep
+a single inference path. Add parity tests: same data as DataFrame vs ndarray
+must yield identical `feature_types`, including columns with NaN and bools.
+
+---
+
+## P2 — Modeling quality (opt-in, no default behavior change)
+
+### 7. Configurable categorical imputer (missingness as a category)
+
+**Problem.** Low-cardinality categoricals use
+`SimpleImputer(strategy="most_frequent")` (`core.py:376`), which hides
+missingness. `strategy="constant", fill_value="missing"` lets OHE create a
+missingness indicator, which is often informative.
+
+**Fix.** Expose a `categorical_imputer` parameter mirroring `numeric_imputer`,
+defaulting to current behavior.
+
+### 8. Cyclical encoding for datetime features
+
+**Problem.** Periodic levels (hour, month, weekday, dayofyear) are emitted as
+plain integers; the wrap-around (hour 23 → 0) is invisible to models.
+
+**Fix.** Add an opt-in `cyclical` flag to `DatetimeEncoder` that emits sin/cos
+pairs for periodic levels. Compose with P0-2 (scaling) so pairs land in a
+sensible range.
+
+### 9. `OrdinalEncoder` unknown sentinel can collide with real codes
+
+**Problem.** `unknown_value=99999` (`core.py:367, 373`) is a real encodable
+integer; at very high cardinality it can collide with a legitimate code.
+
+**Fix.** Use `unknown_value=np.nan` (supported by sklearn) so unknowns surface
+as missing downstream.
+
+### 10. Expose `TargetEncoder` knobs (optional)
+
+**Problem.** `TargetEncoder(cv=3)` is hard-coded (`core.py:370`); `cv`,
+`smooth`, and `target_type` may need tuning for small or regression targets.
+
+**Fix.** Accept a dict of overrides or allow passing a configured
+`TargetEncoder` instance (already possible via `TransformerMixin` input — in
+that case just document it and skip this item).
+
+---
+
+## P3 — Hygiene
+
+### 11. `DatetimeEncoder.get_feature_names_out` returns a `list`
+
+Sklearn convention is `np.ndarray` of str (`datetime.py:133-141`). Return
+`np.asarray(feature_names)`.
+
+### 12. `DatetimeEncoder` string-dtype check misses pandas `string` dtype
+
+`X.dtypes.iloc[0] in (object, str)` (`datetime.py:74, 119`) does not match
+pandas 2.x `StringDtype`; use `pd.api.types.is_string_dtype` (excluding
+categorical) so string-typed date columns are parsed by `pd.to_datetime`
+before validation.
+
+### 13. Lazy-import `IterativeImputer`
+
+The experimental enable import runs at module import time
+(`core.py:13`) even when the iterative imputer is never used. Move it inside
+the `numeric_imputer == "iterative"` branch.
+
+---
+
+## Tests to add (mapped to items)
+
+| Item | Test |
+| --- | --- |
+| 1 | Feature names identical across type compositions |
+| 2 | Datetime-derived features are scaled; imputation strategy respected |
+| 6 | ndarray vs DataFrame inference parity (incl. NaN and bool columns) |
+| 7 | `categorical_imputer="constant"` produces a missingness OHE column |
+| 9 | Unknown category at transform time yields NaN, not 99999 |
+| 11 | `get_feature_names_out` returns `np.ndarray` of str |
+| 12 | `string`-dtype datetime column is parsed and encoded |
+
+(Existing coverage lives in `tests/test_preprocessing.py`.)

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -715,8 +715,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
                 print(assigned_types_df)
 
         self.feature_types = assigned_types
-        self._poniard_preprocessor.feature_types = assigned_types
-        self._poniard_preprocessor.build()
+        self._poniard_preprocessor.build(feature_types=assigned_types)
         self.preprocessor = self._poniard_preprocessor.preprocessor
         self.pipelines = self._build_pipelines()
         return self

--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -166,7 +166,6 @@ class PoniardPreprocessor:
         scaler: Literal["standard", "minmax", "robust"] | TransformerMixin | None = None,
         high_cardinality_encoder: (Literal["target", "ordinal"] | TransformerMixin | None) = None,
         numeric_imputer: Literal["simple", "iterative"] | TransformerMixin | None = None,
-        custom_preprocessor: Pipeline | TransformerMixin | None = None,
         numeric_threshold: int | float = 0.1,
         cardinality_threshold: int | float = 20,
         verbose: bool = False,
@@ -180,7 +179,6 @@ class PoniardPreprocessor:
             "scaler": scaler,
             "high_cardinality_encoder": high_cardinality_encoder,
             "numeric_imputer": numeric_imputer,
-            "custom_preprocessor": custom_preprocessor,
             "numeric_threshold": numeric_threshold,
             "cardinality_threshold": cardinality_threshold,
             "verbose": verbose,
@@ -213,6 +211,7 @@ class PoniardPreprocessor:
         y: pd.DataFrame | np.ndarray | list | None = None,
         task: Task | None = None,
         target_info: dict | None = None,
+        feature_types: dict | None = None,
     ) -> PoniardPreprocessor:
         """Builds the preprocessor according to the input data.
 
@@ -229,6 +228,9 @@ class PoniardPreprocessor:
             Task type ("classification" or "regression"). Overrides the task set at init.
         target_info :
             Target info dict. If None, computed from y and task.
+        feature_types :
+            Explicit feature type assignment. If given, type inference is skipped and
+            ``inferred_types_df`` is refreshed from this mapping.
         """
         if task:
             self.task = task
@@ -238,13 +240,21 @@ class PoniardPreprocessor:
         self._setup_data(X=X, y=y)
         X = self.X
 
-        try:
-            numeric = self.feature_types["numeric"]
-            categorical_high = self.feature_types["categorical_high"]
-            categorical_low = self.feature_types["categorical_low"]
-            datetime = self.feature_types["datetime"]
-        except AttributeError:
-            numeric, categorical_high, categorical_low, datetime = self._infer_dtypes()
+        if feature_types is not None:
+            self.feature_types = feature_types
+            self.inferred_types_df = self._feature_types_df(feature_types)
+            numeric = feature_types["numeric"]
+            categorical_high = feature_types["categorical_high"]
+            categorical_low = feature_types["categorical_low"]
+            datetime = feature_types["datetime"]
+        else:
+            try:
+                numeric = self.feature_types["numeric"]
+                categorical_high = self.feature_types["categorical_high"]
+                categorical_low = self.feature_types["categorical_low"]
+                datetime = self.feature_types["datetime"]
+            except AttributeError:
+                numeric, categorical_high, categorical_low, datetime = self._infer_dtypes()
 
         if target_info:
             self.target_info = target_info
@@ -258,63 +268,41 @@ class PoniardPreprocessor:
         ) = self._setup_transformers()
 
         if isinstance(X, pd.DataFrame):
-            type_preprocessor = ColumnTransformer(
-                [
-                    ("numeric_preprocessor", numeric_preprocessor, numeric),
-                    (
-                        "categorical_low_preprocessor",
-                        cat_low_preprocessor,
-                        categorical_low,
-                    ),
-                    (
-                        "categorical_high_preprocessor",
-                        cat_high_preprocessor,
-                        categorical_high,
-                    ),
-                    ("datetime_preprocessor", datetime_preprocessor, datetime),
-                ],
-                n_jobs=self.n_jobs,
-            )
+            transformers = [
+                ("numeric_preprocessor", numeric_preprocessor, numeric),
+                (
+                    "categorical_low_preprocessor",
+                    cat_low_preprocessor,
+                    categorical_low,
+                ),
+                (
+                    "categorical_high_preprocessor",
+                    cat_high_preprocessor,
+                    categorical_high,
+                ),
+                ("datetime_preprocessor", datetime_preprocessor, datetime),
+            ]
         else:
+            transformers = [
+                ("numeric_preprocessor", numeric_preprocessor, numeric),
+                (
+                    "categorical_low_preprocessor",
+                    cat_low_preprocessor,
+                    categorical_low,
+                ),
+                (
+                    "categorical_high_preprocessor",
+                    cat_high_preprocessor,
+                    categorical_high,
+                ),
+            ]
             if np.issubdtype(X.dtype, np.datetime64):
-                type_preprocessor = datetime_preprocessor
-            elif np.issubdtype(X.dtype, np.number):
-                type_preprocessor = ColumnTransformer(
-                    [
-                        ("numeric_preprocessor", numeric_preprocessor, numeric),
-                        (
-                            "categorical_low_preprocessor",
-                            cat_low_preprocessor,
-                            categorical_low,
-                        ),
-                        (
-                            "categorical_high_preprocessor",
-                            cat_high_preprocessor,
-                            categorical_high,
-                        ),
-                    ],
-                    n_jobs=self.n_jobs,
-                )
-            else:
-                type_preprocessor = ColumnTransformer(
-                    [
-                        (
-                            "categorical_low_preprocessor",
-                            cat_low_preprocessor,
-                            categorical_low,
-                        ),
-                        (
-                            "categorical_high_preprocessor",
-                            cat_high_preprocessor,
-                            categorical_high,
-                        ),
-                    ],
-                    n_jobs=self.n_jobs,
-                )
-        non_empty_transformers = [x for x in type_preprocessor.transformers if x[2] != []]
-        type_preprocessor.transformers = non_empty_transformers
-        if len(type_preprocessor.transformers) == 1:
-            type_preprocessor = type_preprocessor.transformers[0][1]
+                transformers = [("datetime_preprocessor", datetime_preprocessor, datetime)]
+        type_preprocessor = ColumnTransformer(
+            [t for t in transformers if t[2] != []],
+            n_jobs=self.n_jobs,
+            verbose_feature_names_out=False,
+        )
         type_preprocessor.set_output(transform="pandas")
         preprocessor = Pipeline(
             [
@@ -336,7 +324,9 @@ class PoniardPreprocessor:
             self.X = coerce_input(X)
             self.y = coerce_input(y)
         elif not hasattr(self, "X") or not hasattr(self, "y"):
-            raise NotImplementedError("Both X and y need to be passed to _setup_data.")
+            raise ValueError(
+                "X and y must be passed to build() (or set by a previous build() call)."
+            )
         return self
 
     def _setup_transformers(self):
@@ -403,11 +393,9 @@ class PoniardPreprocessor:
         )
         datetime_preprocessor = Pipeline(
             [
-                (
-                    "datetime_encoder",
-                    DatetimeEncoder(),
-                ),
-                ("datetime_imputer", cat_date_imputer),
+                ("datetime_encoder", DatetimeEncoder()),
+                ("datetime_imputer", SimpleImputer(strategy="median")),
+                ("scaler", scaler),
             ],
         )
         return (
@@ -428,15 +416,17 @@ class PoniardPreprocessor:
         self.feature_types = infer_feature_types(
             self.X, self.numeric_threshold, self.cardinality_threshold
         )
-        self.inferred_types_df = pd.DataFrame.from_dict(
-            self.feature_types, orient="index"
-        ).T.fillna("")
+        self.inferred_types_df = self._feature_types_df(self.feature_types)
         return (
             self.feature_types["numeric"],
             self.feature_types["categorical_high"],
             self.feature_types["categorical_low"],
             self.feature_types["datetime"],
         )
+
+    @staticmethod
+    def _feature_types_df(feature_types: dict) -> pd.DataFrame:
+        return pd.DataFrame.from_dict(feature_types, orient="index").T.fillna("")
 
     def __repr__(self):
         return non_default_repr(self)

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -242,16 +242,11 @@ class TestPreprocessing:
         pp = PoniardPreprocessor()
         pp.build(X=X, y=y, task="classification")
         ct = pp.preprocessor.named_steps["type_preprocessor"]
-        if isinstance(ct, ColumnTransformer):
-            numeric_pipeline = dict(ct.named_transformers_)["numeric_preprocessor"]
-        else:
-            # Single transformer — the whole preprocessor IS the numeric one
-            numeric_pipeline = ct
-        step_names = (
-            [s for s, _ in numeric_pipeline.steps] if hasattr(numeric_pipeline, "steps") else []
-        )
-        has_scaler = any("scaler" in s.lower() for s in step_names)
-        assert has_scaler or isinstance(numeric_pipeline, Pipeline)
+        assert isinstance(ct, ColumnTransformer)
+        numeric_pipeline = self._get_transformer_by_name(ct, "numeric_preprocessor")
+        assert isinstance(numeric_pipeline, Pipeline)
+        assert isinstance(numeric_pipeline.named_steps["numeric_imputer"], SimpleImputer)
+        assert isinstance(numeric_pipeline.named_steps["scaler"], StandardScaler)
 
     @staticmethod
     def _get_transformer_by_name(ct, name):

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -146,3 +146,42 @@ def test_add_step(new_step, position, existing_step):
     reg = PoniardRegressor(custom_preprocessor=existing_step).setup(X, y)
     reg.add_preprocessing_step(new_step, position)
     assert isinstance(reg.preprocessor, Pipeline)
+
+
+def test_feature_names_stable_across_type_compositions():
+    base = pd.DataFrame(
+        {
+            "A": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "B": ["a", "b", "a", "b", "a"],
+            "D": pd.date_range("2020-01-01", periods=5),
+        }
+    )
+    y = np.array([0, 1, 0, 1, 0])
+    pp_full = PoniardPreprocessor().build(X=base, y=y, task="classification")
+    pp_numeric = PoniardPreprocessor().build(X=base[["A"]], y=y, task="classification")
+    pp_full.preprocessor.fit(base, y)
+    pp_numeric.preprocessor.fit(base[["A"]], y)
+    full_names = pp_full.preprocessor.get_feature_names_out()
+    numeric_names = pp_numeric.preprocessor.get_feature_names_out()
+    assert list(full_names) == ["A", "B_b", "D_day", "D_weekday", "D_dayofyear"]
+    assert list(numeric_names) == ["A"]
+
+
+def test_datetime_features_scaled_and_imputed():
+    dates = pd.date_range("2020-01-01", freq="h", periods=99).to_list()
+    dates.insert(0, pd.NaT)
+    X = pd.DataFrame({"D": dates})
+    y = np.random.RandomState(0).randint(0, 2, size=100)
+    pp = PoniardPreprocessor().build(X=X, y=y, task="classification")
+    out = pp.preprocessor.fit_transform(X, y)
+    assert not out.isna().any().any()
+    assert {"D_day", "D_hour", "D_weekday", "D_dayofyear"} <= set(out.columns)
+    for col in ("D_day", "D_hour", "D_weekday", "D_dayofyear"):
+        assert np.allclose(out[col].mean(), 0, atol=1e-8)
+        assert np.allclose(out[col].std(ddof=0), 1, atol=1e-8)
+
+
+def test_build_without_data_raises_clear_error():
+    pp = PoniardPreprocessor(task="classification")
+    with pytest.raises(ValueError, match="X and y must be passed to build"):
+        pp.build()


### PR DESCRIPTION
Resolves the P0 items in `docs/preprocessing-improvements.md`.

**Changes:**
- **Stable feature names**: `verbose_feature_names_out=False` and no more unwrapping of single-transformer `ColumnTransformer`s, so output names no longer change when a feature type is added/removed.
- **Datetime scaling**: datetime pipeline is now `DatetimeEncoder → SimpleImputer(median) → scaler`, matching the numeric pipeline.
- **Remove dead `custom_preprocessor` param** from `PoniardPreprocessor` (the estimator layer already handles custom preprocessors).
- **Clear `build()` error**: raises `ValueError` instead of a confusing `NotImplementedError` referencing a private method.
- **Explicit `feature_types`**: `build()` now accepts `feature_types` and refreshes `inferred_types_df`; `reassign_types` uses it instead of mutating the attribute.

**Tests:** added for items 1, 2 and the `build()` error; updated one test that depended on the removed unwrap behavior. Full suite: 229 passed, ruff clean.

⚠️ Note: `docs/preprocessing-improvements.md` is untracked and left out of the commit.