### PR TITLE
fix: unify pandas and numpy feature type inference

### DIFF
--- a/poniard/preprocessing/core.py
+++ b/poniard/preprocessing/core.py
@@ -65,6 +65,9 @@ def infer_feature_types(
     categorical_low: list = []
     datetime_cols: list = []
 
+    if isinstance(X, np.ndarray):
+        X = pd.DataFrame(X)
+
     cardinality_threshold = (
         cardinality_threshold
         if isinstance(cardinality_threshold, int)
@@ -76,44 +79,25 @@ def infer_feature_types(
         else int(numeric_threshold * X.shape[0])
     )
 
-    if isinstance(X, pd.DataFrame):
-        for col in X.columns:
-            dtype = X[col].dtype
-            nunique = X[col].nunique()
+    for col in X.columns:
+        dtype = X[col].dtype
+        nunique = X[col].nunique()
 
-            if pd.api.types.is_datetime64_any_dtype(dtype):
-                datetime_cols.append(col)
-            elif pd.api.types.is_numeric_dtype(dtype):
-                if nunique > numeric_threshold:
-                    numeric.append(col)
-                elif nunique > cardinality_threshold:
-                    categorical_high.append(col)
-                else:
-                    categorical_low.append(col)
+        if pd.api.types.is_datetime64_any_dtype(dtype):
+            datetime_cols.append(col)
+        elif pd.api.types.is_numeric_dtype(dtype) and not pd.api.types.is_bool_dtype(dtype):
+            if nunique > numeric_threshold:
+                numeric.append(col)
+            elif nunique > cardinality_threshold:
+                categorical_high.append(col)
             else:
-                # strings, objects, categorical, boolean
-                if nunique > cardinality_threshold:
-                    categorical_high.append(col)
-                else:
-                    categorical_low.append(col)
-    else:
-        for i in range(X.shape[1]):
-            col = X[:, i]
-            nunique = len(np.unique(col))
-            if np.issubdtype(col.dtype, np.datetime64):
-                datetime_cols.append(i)
-            elif np.issubdtype(col.dtype, np.number):
-                if nunique > numeric_threshold:
-                    numeric.append(i)
-                elif nunique > cardinality_threshold:
-                    categorical_high.append(i)
-                else:
-                    categorical_low.append(i)
+                categorical_low.append(col)
+        else:
+            # strings, objects, categorical, boolean
+            if nunique > cardinality_threshold:
+                categorical_high.append(col)
             else:
-                if nunique > cardinality_threshold:
-                    categorical_high.append(i)
-                else:
-                    categorical_low.append(i)
+                categorical_low.append(col)
 
     return {
         "numeric": numeric,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -9,7 +9,7 @@ from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import StandardScaler
 
 from poniard import PoniardClassifier, PoniardRegressor
-from poniard.preprocessing import PoniardPreprocessor
+from poniard.preprocessing import PoniardPreprocessor, infer_feature_types
 
 
 @pytest.mark.parametrize(
@@ -185,3 +185,46 @@ def test_build_without_data_raises_clear_error():
     pp = PoniardPreprocessor(task="classification")
     with pytest.raises(ValueError, match="X and y must be passed to build"):
         pp.build()
+
+
+@pytest.mark.parametrize(
+    "array,frame",
+    [
+        (
+            np.array(
+                [
+                    [1.0, np.nan, 3.0],
+                    [4.0, 5.0, np.nan],
+                    [1.0, 2.0, 3.0],
+                    [7.0, 8.0, 9.0],
+                    [1.0, 2.0, 3.0],
+                ],
+                dtype=float,
+            ),
+            pd.DataFrame(
+                [
+                    [1.0, np.nan, 3.0],
+                    [4.0, 5.0, np.nan],
+                    [1.0, 2.0, 3.0],
+                    [7.0, 8.0, 9.0],
+                    [1.0, 2.0, 3.0],
+                ],
+                dtype=float,
+            ),
+        ),
+        (
+            np.array([[True, False], [False, True], [True, True], [False, False], [True, False]]),
+            pd.DataFrame(
+                [[True, False], [False, True], [True, True], [False, False], [True, False]]
+            ),
+        ),
+        (
+            pd.date_range("2020-01-01", periods=5).to_numpy().reshape(-1, 1),
+            pd.DataFrame(pd.date_range("2020-01-01", periods=5).to_numpy().reshape(-1, 1)),
+        ),
+    ],
+)
+def test_inference_parity_dataframe_vs_ndarray(array, frame):
+    from_array = infer_feature_types(array, numeric_threshold=2, cardinality_threshold=3)
+    from_frame = infer_feature_types(frame, numeric_threshold=2, cardinality_threshold=3)
+    assert from_array == from_frame


### PR DESCRIPTION
Resolves P1 item 6 in `docs/preprocessing-improvements.md`.

**Problem.** `infer_feature_types` had two duplicated branches (DataFrame vs ndarray) that disagreed on edge cases:
- pandas `nunique()` ignores NaN, `np.unique` counts it — same column could classify differently by container.
- `pd.api.types.is_numeric_dtype(bool)` is True while `np.issubdtype(bool, np.number)` is False, so bools took different paths.

**Change.** Coerce ndarray input to a DataFrame once and keep a single inference path. Booleans are now consistently treated as categorical (matching the existing intent/test), and NaN handling is identical across containers.

**Tests.** Added the doc-mapped parity test: same data as DataFrame vs ndarray must yield identical `feature_types`, covering numeric-with-NaN, bool, and datetime columns.

Full suite: 232 passed, ruff clean.