### PR TITLE
feat: regression default metrics — RMSE first, MAPE only for positive targets

### DIFF
--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -97,12 +97,14 @@ class PoniardRegressor(PoniardBaseEstimator):
         ]
 
     def _build_metrics(self) -> dict[str, Callable] | list[str]:
-        return [
-            "neg_mean_squared_error",
-            "neg_mean_absolute_percentage_error",
-            "neg_median_absolute_error",
+        metrics = [
+            "neg_root_mean_squared_error",
+            "neg_mean_absolute_error",
             "r2",
         ]
+        if self.target_info and self.target_info.get("positive"):
+            metrics.append("neg_mean_absolute_percentage_error")
+        return metrics
 
     def _build_cv(self) -> BaseCrossValidator:
         cv = self.cv or 5

--- a/poniard/utils/estimate.py
+++ b/poniard/utils/estimate.py
@@ -38,7 +38,17 @@ def get_target_info(y: pd.DataFrame | pd.Series | np.ndarray, task: Task) -> dic
     # dataset is 'multiclass' according to this function when it should be 'continuous'.
     if type_of_target_ == "multiclass" and task == "regression":
         type_of_target_ = "continuous"
-    return dict(type_=type_of_target_, ndim=y.ndim, shape=y.shape, nunique=np.unique(y).size)
+    if task == "regression":
+        positive = bool(np.all(np.isfinite(y)) and np.all(y > 0))
+    else:
+        positive = False
+    return dict(
+        type_=type_of_target_,
+        ndim=y.ndim,
+        shape=y.shape,
+        nunique=np.unique(y).size,
+        positive=positive,
+    )
 
 
 def element_to_list_maybe(obj):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "scikit-learn>=1.3.0",
+    "scikit-learn>=1.4.0",
     "pandas>=2.0.0",
     "numpy>=1.26.0",
     "scipy>=1.11.0",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -123,6 +123,36 @@ def test_regressor_fit(target, metrics, estimators, cv):
     assert results.shape == (n_estimators + 1, n_metrics * 2 + 4)
 
 
+def test_regressor_default_metrics():
+    X, y = make_regression(n_samples=60, n_features=4, random_state=42)
+    reg = PoniardRegressor(estimators=[LinearRegression()], cv=3, random_state=0)
+    reg.setup(pd.DataFrame(X), y)
+    assert reg.metrics[0] == "neg_root_mean_squared_error"
+    assert "neg_mean_absolute_percentage_error" not in reg.metrics
+
+
+def test_regressor_positive_target_includes_mape():
+    X, y = make_regression(n_samples=60, n_features=4, random_state=42)
+    reg = PoniardRegressor(estimators=[LinearRegression()], cv=3, random_state=0)
+    reg.setup(pd.DataFrame(X), np.exp(y))
+    assert reg.metrics == [
+        "neg_root_mean_squared_error",
+        "neg_mean_absolute_error",
+        "r2",
+        "neg_mean_absolute_percentage_error",
+    ]
+
+
+def test_regressor_zero_target_scores_cleanly():
+    X, y = make_regression(n_samples=60, n_features=4, random_state=42)
+    y_zero = np.where(y > 0, y, 0.0)
+    reg = PoniardRegressor(estimators=[LinearRegression()], cv=3, random_state=0)
+    reg.fit(pd.DataFrame(X), y_zero)
+    results = reg.get_results()
+    assert "test_neg_mean_absolute_percentage_error" not in results.columns
+    assert not results.isna().any().any()
+
+
 def test_multilabel_fit():
     import warnings
 
@@ -160,7 +190,7 @@ def test_multioutput_fit():
         clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (3, 12)
+    assert results.shape == (3, len(clf.metrics) * 2 + 4)
 
 
 def test_type_inference():

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -478,10 +478,10 @@ class TestResults:
         results = fitted_regressor.get_results()
         # 1 custom + DummyRegressor = 2 rows
         assert results.shape[0] == 2
-        # Regressor metrics: neg_mean_squared_error, neg_mean_absolute_percentage_error,
-        # neg_median_absolute_error, r2 = 4 test cols + fit_time + score_time
+        # Regressor metrics: neg_root_mean_squared_error, neg_mean_absolute_error, r2
+        # (no MAPE on a mixed-sign target) = 3 test cols + fit_time + score_time
         score_cols = [c for c in results.columns if c.startswith("test_")]
-        assert len(score_cols) == 4
+        assert len(score_cols) == 3
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Implements **P0-3** from the ML defaults improvements plan (`docs/ml-defaults-improvements.md`).

### Changes
- Default regression metrics become `["neg_root_mean_squared_error", "neg_mean_absolute_error", "r2"]`.
  - RMSE is now the primary metric (first column), used as the ranking/ensemble sort key.
  - `neg_mean_squared_error` was outlier-dominated; `neg_median_absolute_error` dropped.
- `neg_mean_absolute_percentage_error` is only included when the target is strictly positive. MAPE epsilon-floors the denominator in sklearn, silently producing astronomical values when `y` contains zeros.
- `get_target_info()` now reports whether a regression target is positive (`positive` key).
- Bumped `scikit-learn` floor to `>=1.4.0` (required for `neg_root_mean_squared_error`).

### Tests
- Defaults: RMSE first, no MAPE on a mixed-sign target.
- Strictly positive target includes MAPE.
- Zero-containing target scores cleanly (no MAPE column, no NaNs).
- Updated the two shape tests that hardcoded the old 4-metric count.

All 244 tests pass; ruff + format clean.