### PR TITLE
feat: classification default metrics — add log-loss and PR AUC

### DIFF
--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -96,8 +96,11 @@ class PoniardClassifier(PoniardBaseEstimator):
         ]
 
     def _build_metrics(self) -> dict[str, Callable] | list[str]:
+        all_have_proba = all(
+            hasattr(est, "predict_proba") for est in self._build_estimators_dict().values()
+        )
         if self.target_info["type_"] == "multilabel-indicator":
-            return [
+            metrics = [
                 "roc_auc",
                 "accuracy",
                 "precision_macro",
@@ -105,22 +108,26 @@ class PoniardClassifier(PoniardBaseEstimator):
                 "f1_macro",
             ]
         elif self.target_info["type_"] == "multiclass":
-            return [
+            metrics = [
                 "roc_auc_ovr",
                 "accuracy",
                 "precision_macro",
                 "recall_macro",
                 "f1_macro",
             ]
-
         else:
-            return [
+            metrics = [
                 "roc_auc",
                 "accuracy",
                 "precision",
                 "recall",
                 "f1",
             ]
+        if all_have_proba:
+            metrics.insert(1, "neg_log_loss")
+            if self.target_info["type_"] == "binary":
+                metrics.insert(2, "average_precision")
+        return metrics
 
     def _build_cv(self) -> BaseCrossValidator:
         cv = self.cv or 5

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -438,17 +438,11 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             i += 1
         return f"{class_name}_{i}"
 
-    def _build_pipelines(
-        self,
-    ) -> dict[str, ClassifierMixin | RegressorMixin]:
-        """Build `pipelines` dict where keys are estimator names.
+    def _build_estimators_dict(self) -> dict[str, ClassifierMixin | RegressorMixin]:
+        """Resolve the estimator dict: defaults or user input, plus added, minus removed.
 
-        Names can be:
-        - A dict: keys are names, values are estimators
-        - A list of tuples: (name, estimator)
-        - A list of estimators: class name if unique, short prefix if duplicates
-
-        Adds dummy estimators if not included during construction.
+        Dummy estimators are not included; they are appended separately in
+        ``_build_pipelines``.
         """
         if isinstance(self.estimators, dict):
             estimators = self.estimators.copy()
@@ -469,6 +463,21 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         estimators.update(self._added_estimators)
         for name in self._removed_estimators:
             estimators.pop(name, None)
+        return estimators
+
+    def _build_pipelines(
+        self,
+    ) -> dict[str, ClassifierMixin | RegressorMixin]:
+        """Build `pipelines` dict where keys are estimator names.
+
+        Names can be:
+        - A dict: keys are names, values are estimators
+        - A list of tuples: (name, estimator)
+        - A list of estimators: class name if unique, short prefix if duplicates
+
+        Adds dummy estimators if not included during construction.
+        """
+        estimators = self._build_estimators_dict()
         estimators = self._add_dummy_estimators(estimators)
 
         pipelines = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.datasets import (
+    make_classification,
     make_multilabel_classification,
     make_regression,
 )
@@ -170,7 +171,18 @@ def test_multilabel_fit():
         clf.fit(X, y)
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
-    assert results.shape == (3, 14)
+    assert results.shape == (3, len(clf.metrics) * 2 + 4)
+
+
+def test_classifier_default_metrics_without_predict_proba():
+    from sklearn.svm import LinearSVC
+
+    X, y = make_classification(n_samples=120, n_features=5, random_state=42)
+    clf = PoniardClassifier(estimators=[LinearSVC(max_iter=5000)], cv=3, random_state=0)
+    clf.setup(pd.DataFrame(X), y)
+    assert clf.metrics[0] == "roc_auc"
+    assert "neg_log_loss" not in clf.metrics
+    assert "average_precision" not in clf.metrics
 
 
 def test_multioutput_fit():
@@ -191,6 +203,39 @@ def test_multioutput_fit():
     results = clf.get_results(return_train_scores=True)
     assert results.isna().sum().sum() == 0
     assert results.shape == (3, len(clf.metrics) * 2 + 4)
+
+
+def test_classifier_binary_default_metrics():
+    X, y = make_classification(n_samples=120, n_features=5, random_state=42)
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=3, random_state=0)
+    clf.setup(pd.DataFrame(X), y)
+    assert clf.metrics[0] == "roc_auc"
+    assert "neg_log_loss" in clf.metrics
+    assert "average_precision" in clf.metrics
+
+
+def test_classifier_multiclass_default_metrics():
+    X, y = make_classification(
+        n_samples=180, n_features=6, n_classes=3, n_informative=4, n_redundant=1, random_state=42
+    )
+    clf = PoniardClassifier(estimators=[LogisticRegression()], cv=3, random_state=0)
+    clf.setup(pd.DataFrame(X), y)
+    assert clf.metrics[0] == "roc_auc_ovr"
+    assert "neg_log_loss" in clf.metrics
+    assert "average_precision" not in clf.metrics
+
+
+def test_classifier_multilabel_default_metrics():
+    import warnings
+
+    X, y = make_multilabel_classification(n_samples=300, n_classes=3, n_labels=3)
+    clf = PoniardClassifier(estimators=[OneVsRestClassifier(LogisticRegression())], random_state=0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="TargetEncoder is not supported")
+        clf.setup(X, y)
+    assert clf.metrics[0] == "roc_auc"
+    assert "neg_log_loss" in clf.metrics
+    assert "average_precision" not in clf.metrics
 
 
 def test_type_inference():

--- a/tests/test_meaningful.py
+++ b/tests/test_meaningful.py
@@ -397,10 +397,12 @@ class TestResults:
         assert results.shape[1] > 0
 
     def test_classification_scores_between_0_and_1(self, fitted_classifier):
-        """All classification metric scores should be in [0, 1]."""
+        """All bounded classification metric scores should be in [0, 1]."""
         results = fitted_classifier.get_results()
         score_cols = [c for c in results.columns if c.startswith("test_")]
-        for col in score_cols:
+        # neg_log_loss is an unbounded loss, not a bounded score
+        bounded_cols = [c for c in score_cols if "log_loss" not in c]
+        for col in bounded_cols:
             assert results[col].between(0, 1).all(), f"Column {col} has values outside [0,1]"
 
     def test_dummy_classifier_gets_prior_score(self, classification_data):


### PR DESCRIPTION
## Summary

Implements **P0-4** from the ML defaults improvements plan (`docs/ml-defaults-improvements.md`).

### Changes
- `neg_log_loss` added to all three default classification metric lists (binary, multiclass, multilabel-indicator).
- `average_precision` added to the binary list (PR AUC is informative under class imbalance).
- `roc_auc`/`roc_auc_ovr` stays first so ranking/ensemble behavior is unchanged.
- **predict_proba gating**: the proba-requiring metrics are only included when every configured estimator supports `predict_proba`. Custom estimators without it (e.g. `LinearSVC`) keep a working default metric set instead of hard-failing in cross-validation (which the existing error-analysis test relied on).
- Factored estimator resolution out of `_build_pipelines` into `_build_estimators_dict()` so `_build_metrics` can inspect the configured estimators.

### Tests
- Binary defaults include `neg_log_loss` and `average_precision`; multiclass/multilabel include `neg_log_loss` only.
- Non-proba estimators drop both.
- Updated multilabel shape test (column count now derived from metrics) and the bounded-scores test (excludes unbounded `neg_log_loss`).

All 248 tests pass; coverage 89.4% (gate 85%); ruff + format clean.