### PR TITLE
feat: pass n_jobs to KNN defaults

### DIFF
--- a/poniard/estimators/classification.py
+++ b/poniard/estimators/classification.py
@@ -87,7 +87,7 @@ class PoniardClassifier(PoniardBaseEstimator):
         return [
             LogisticRegression(random_state=self.random_state, verbose=self.verbose, max_iter=5000),
             GaussianNB(),
-            KNeighborsClassifier(),
+            KNeighborsClassifier(n_jobs=self.n_jobs),
             DecisionTreeClassifier(random_state=self.random_state),
             RandomForestClassifier(
                 random_state=self.random_state, verbose=self.verbose, n_jobs=self.n_jobs

--- a/poniard/estimators/regression.py
+++ b/poniard/estimators/regression.py
@@ -88,7 +88,7 @@ class PoniardRegressor(PoniardBaseEstimator):
             LinearRegression(),
             ElasticNet(random_state=self.random_state),
             LinearSVR(verbose=self.verbose, random_state=self.random_state, max_iter=5000),
-            KNeighborsRegressor(),
+            KNeighborsRegressor(n_jobs=self.n_jobs),
             DecisionTreeRegressor(random_state=self.random_state),
             RandomForestRegressor(
                 random_state=self.random_state, verbose=self.verbose, n_jobs=self.n_jobs

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,6 +185,20 @@ def test_classifier_default_metrics_without_predict_proba():
     assert "average_precision" not in clf.metrics
 
 
+def test_knn_default_pipeline_carries_n_jobs():
+    X, y = make_classification(n_samples=60, n_features=4, random_state=42)
+    clf = PoniardClassifier(n_jobs=2, random_state=0)
+    clf.setup(pd.DataFrame(X), y, show_info=False)
+    knn = clf.pipelines["KNeighborsClassifier"]
+    assert knn.named_steps["KNeighborsClassifier"].n_jobs == 2
+
+    Xr, yr = make_regression(n_samples=60, n_features=4, random_state=42)
+    reg = PoniardRegressor(n_jobs=3, random_state=0)
+    reg.setup(pd.DataFrame(Xr), yr, show_info=False)
+    knn_r = reg.pipelines["KNeighborsRegressor"]
+    assert knn_r.named_steps["KNeighborsRegressor"].n_jobs == 3
+
+
 def test_multioutput_fit():
     import warnings
 


### PR DESCRIPTION
## Summary

Implements **P1-6** from the ML defaults improvements plan (`docs/ml-defaults-improvements.md`).

### Changes
- `KNeighborsClassifier` and `KNeighborsRegressor` are now constructed with `n_jobs=self.n_jobs`, matching RandomForest.

### Tests
- Default KNN pipelines carry the estimator's `n_jobs` (classifier and regressor).

All 252 tests pass; ruff + format clean.