### PR TITLE
feat: ensemble support for mixed per-estimator preprocessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ model = clf.get_estimator("LogisticRegression", retrain=True, X=X, y=y)
 | **Error analysis** | Universal failures, disagreement sets, lift vs baseline — ranked per sample, sliced by target and features |
 | **Statistical comparison** | Paired fold tests so you stop trusting fold-mean leaderboards |
 | **Time / quality** | Pareto front and best-under-budget helpers |
-| **Preprocessing** | Automatic numeric / categorical / datetime type inference, imputation, encoding, scaling |
+| **Preprocessing** | Automatic numeric / categorical / datetime type inference, imputation, encoding, scaling; per-estimator preprocessors (`preprocessor_map`) with a native profile for HistGradientBoosting |
 | **Tuning** | Grid, random, and halving search that re-enters the experiment as a new named estimator |
 | **Ensembles** | Diversity-aware voting / stacking built from your fitted estimators |
 | **Plotting** | Metrics, ROC, confusion matrices, residuals, feature importance (optional, requires `[plot]`) |
@@ -117,6 +117,7 @@ model = clf.get_estimator("LogisticRegression", retrain=True, X=X, y=y)
   - `examples/00_getting_started.py` — fit, results, predictions
   - `examples/01_error_analysis.py` — full failure-forensics workflow
   - `examples/02_plotting.py` — the plotting API
+  - `examples/03_preprocessing.py` — per-estimator preprocessors and the native profile
 
 ```bash
 python examples/00_getting_started.py

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -42,8 +42,10 @@ flow exists so the preprocessor is never a black box.
 - `reassign_types(numeric=..., categorical_high=..., categorical_low=..., datetime=..., keep_remainder=True)`
   — override type inference. Omitted features keep their inferred type unless
   `keep_remainder=False`.
-- `add_preprocessing_step(step, position="end")` — insert a transformer into the
-  preprocessor pipeline (`"start"`, `"end"`, or an integer index).
+- `add_preprocessing_step(step, position="end", preprocessor="all")` — insert a
+  transformer into the preprocessor pipeline (`"start"`, `"end"`, or an integer
+  index), optionally targeting specific registered templates (see
+  [Per-estimator preprocessors](#per-estimator-preprocessors)).
 - `add_estimators(...)` / `remove_estimators(names, drop_results=True)` — change
   the estimator set. These are the supported ways to mutate `pipelines`: they
   handle naming collisions, attribute propagation, and result bookkeeping.
@@ -62,11 +64,12 @@ Type inference classifies every feature as one of:
 | `numeric` | number-like with `nunique > numeric_threshold` | imputer (`median` default, or `mean`/`iterative`) with missingness indicator + scaler (`standard`/`minmax`/`robust`) |
 | `categorical_low` | not numeric, `nunique <= cardinality_threshold` | most-frequent imputer + `OneHotEncoder(drop="if_binary", min_frequency=5)` |
 | `categorical_high` | not numeric, `nunique > cardinality_threshold` | most-frequent imputer + `TargetEncoder` (ordinal for multioutput targets) |
-| `datetime` | datetime dtype | `DatetimeEncoder` + most-frequent imputer |
+| `datetime` | datetime dtype | `DatetimeEncoder` + median imputer + scaler |
 
 Thresholds can be integers (a count) or floats (a fraction of rows). Defaults:
-`numeric_threshold=0.1`, `cardinality_threshold=20`. A `VarianceThreshold` step
-removes invariant features at the end.
+`numeric_threshold=0.1`, `cardinality_threshold=20`. In the `"default"` profile a
+`VarianceThreshold` step removes invariant features at the end (the `"native"`
+profile skips it — see below).
 
 The preprocessor is a plain `sklearn.pipeline.Pipeline` configured to output
 pandas DataFrames (`set_output(transform="pandas")`), without touching sklearn's
@@ -106,7 +109,7 @@ untouched (tree models learn NaN split directions themselves) and
 ordinal-encodes categoricals as pandas `category` dtype so the estimator splits
 on them directly. It is only valid for `HistGradientBoosting*` estimators, which
 get `categorical_features="from_dtype"` set automatically as a side effect.
-Everything else falls back to `"default"`.
+Mapping it to anything else raises `ValueError`.
 
 Templates can be registered and assigned at runtime:
 
@@ -116,8 +119,22 @@ clf.set_preprocessor("LogisticRegression", "sparse_friendly")  # (re)assign
 clf.preprocessor_map                                    # inspect
 ```
 
-`add_preprocessing_step` can target specific templates with
-`preprocessor="name"` (default `"all"`).
+- `preprocessor_map` values may be a registered name (`"default"`, `"native"`, or
+  a template you registered) or an actual `Pipeline`/`Transformer`, which is
+  auto-registered under a generated name.
+- `set_preprocessor` validates both the estimator and the template name, then
+  rebuilds that estimator's pipeline immediately.
+- `add_preprocessing_step(step, preprocessor="name")` targets specific templates;
+  `"all"` (the default) applies the step to every template.
+- `reassign_types` rebuilds every `PoniardPreprocessor`-backed profile (default
+  and native) with the new types — type inference still runs exactly once, shared
+  by all profiles. User-supplied `Pipeline` templates are left untouched.
+
+**Ensembles.** `build_ensemble` wraps the ensemble in a preprocessor only when
+all selected members map to the **same** template (preprocessing runs once).
+When members are mixed (e.g. one on `"native"`, one on `"default"`), each member
+contributes its own full pipeline and the ensemble is added with no outer
+preprocessor — the only way to combine differently-preprocessed members.
 
 ---
 
@@ -286,6 +303,13 @@ best-N-by-metric behavior, or `estimator_names=[...]` to bypass selection.
 ```python
 clf.fit(X, y)      # the ensemble joins the results table
 ```
+
+The ensemble's own preprocessing follows the members' `preprocessor_map`: if
+every selected member maps to the same template, the ensemble is wrapped in it
+(preprocessing runs once on bare estimators); if members use different
+preprocessors (e.g. an HGB on `"native"` and a linear model on `"default"`),
+each member carries its full pipeline and the ensemble is added without an outer
+preprocessor.
 
 ---
 

--- a/examples/03_preprocessing.py
+++ b/examples/03_preprocessing.py
@@ -1,0 +1,87 @@
+"""Per-estimator preprocessors: the default profile and the native HGB profile.
+
+This example uses data with missing values, low- and high-cardinality
+categoricals, and a datetime column, then shows:
+
+1. The default preprocessor: median imputation with missingness indicators,
+   one-hot encoding (with min_frequency), and scaling.
+2. Routing HistGradientBoosting to the "native" profile via preprocessor_map,
+   which leaves numeric/datetime untouched and ordinal-encodes categoricals to
+   pandas category dtype so HGB handles them natively.
+3. Registering a custom template and assigning it at runtime.
+"""
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.linear_model import LogisticRegression
+
+from poniard import PoniardClassifier
+from poniard.preprocessing import PoniardPreprocessor
+
+rng = np.random.RandomState(42)
+n = 120
+X = pd.DataFrame(
+    {
+        "num": rng.normal(size=n),
+        "num_missing": np.where(rng.rand(n) < 0.2, np.nan, rng.normal(size=n)),
+        "cat_low": rng.choice(["a", "b", "c"], size=n),
+        "cat_high": [f"c_{i}" for i in range(n)],
+        "dt": pd.date_range("2020-01-01", periods=n, freq="D"),
+    }
+)
+y = make_classification(n_samples=n, n_features=5, random_state=42)[1]
+
+# 1. Default preprocessor on all estimators.
+clf = PoniardClassifier(
+    estimators=[LogisticRegression(max_iter=1000), HistGradientBoostingClassifier()],
+    cv=3,
+    random_state=0,
+)
+clf.setup(X, y, show_info=False)
+print("Registered preprocessors:", list(clf.preprocessors))
+print("Default profile steps:", [s for s, _ in clf.preprocessors["default"].steps])
+print()
+
+# 2. Route HGB to the "native" profile. It keeps NaNs and categoricals raw
+#    (as category dtype) instead of imputing/one-hot encoding them away.
+clf = PoniardClassifier(
+    estimators=[
+        HistGradientBoostingClassifier(),
+        LogisticRegression(max_iter=1000),
+    ],
+    cv=3,
+    random_state=0,
+    preprocessor_map={"HistGradientBoostingClassifier": "native"},
+)
+clf.fit(X, y, show_info=False)
+print("Preprocessor map:", clf.preprocessor_map)
+hgb_est = clf.pipelines["HistGradientBoostingClassifier"].named_steps[
+    "HistGradientBoostingClassifier"
+]
+print(
+    "HGB categorical_features (auto-set):",
+    hgb_est.categorical_features,
+)
+print(clf.get_results()[["test_roc_auc", "test_neg_log_loss"]].round(3))
+print()
+
+# 3. Register a custom template and assign it at runtime. A registered template
+#    must handle the full feature set, so build one from a configured
+#    PoniardPreprocessor (here: min-max scaling instead of the standard scaler).
+clf = PoniardClassifier(
+    estimators=[HistGradientBoostingClassifier(), LogisticRegression(max_iter=1000)],
+    cv=3,
+    random_state=0,
+    preprocessor_map={"HistGradientBoostingClassifier": "native"},
+)
+clf.setup(X, y, show_info=False)
+minmax_pp = PoniardPreprocessor(scaler="minmax")
+minmax_pp.build(X, y, task="classification")
+clf.add_preprocessor("minmax", minmax_pp.preprocessor)
+clf.set_preprocessor("LogisticRegression", "minmax")
+print("Map after set_preprocessor:", clf.preprocessor_map)
+clf.fit(X, y, show_info=False)
+assert not clf.get_results().isna().any().any()
+print("Mixed-preprocessor experiment scored cleanly.")

--- a/poniard/estimators/core.py
+++ b/poniard/estimators/core.py
@@ -15,7 +15,14 @@ import pandas as pd
 from sklearn.base import ClassifierMixin, RegressorMixin, TransformerMixin, clone
 from sklearn.compose import ColumnTransformer
 from sklearn.dummy import DummyClassifier, DummyRegressor
-from sklearn.ensemble import HistGradientBoostingClassifier, HistGradientBoostingRegressor
+from sklearn.ensemble import (
+    HistGradientBoostingClassifier,
+    HistGradientBoostingRegressor,
+    StackingClassifier,
+    StackingRegressor,
+    VotingClassifier,
+    VotingRegressor,
+)
 from sklearn.exceptions import UndefinedMetricWarning
 from sklearn.model_selection import (
     cross_val_predict,
@@ -494,7 +501,9 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     def _default_estimators(self) -> list[ClassifierMixin]:
         return []
 
-    def _make_pipeline(self, name: str, estimator) -> Pipeline:
+    def _make_pipeline(
+        self, name: str, estimator, include_preprocessor: bool | None = None
+    ) -> Pipeline:
         """Create a Pipeline for an estimator, optionally including the preprocessor.
 
         The estimator is cloned and configured (random_state, verbose) so the
@@ -505,10 +514,23 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         configured to output pandas DataFrames on ``transform``, propagating to
         any preprocessor step so downstream code keeps the pandas contract
         without relying on a global sklearn config.
+
+        Parameters
+        ----------
+        name :
+            Estimator name.
+        estimator :
+            The estimator to wrap.
+        include_preprocessor :
+            ``None`` (default) resolves from ``self.preprocess``. ``False``
+            builds a bare pipeline (used when the estimator already contains
+            its own preprocessing, e.g. mixed-preprocessor ensembles).
         """
         estimator = clone(estimator)
         self._pass_instance_attrs(estimator)
-        if self.preprocess:
+        if include_preprocessor is None:
+            include_preprocessor = self.preprocess
+        if include_preprocessor:
             prep_name = self.preprocessor_map.get(name, "default")
             preprocessor = self.preprocessors[prep_name]
             if prep_name == "native":
@@ -519,7 +541,7 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
             )
         else:
             pipe = Pipeline([(name, estimator)])
-        if self.preprocess:
+        if include_preprocessor:
             pipe.set_output(transform="pandas")
         return pipe
 
@@ -527,12 +549,19 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
     def _configure_native_estimator(estimator, name: str) -> None:
         """Couple the ``"native"`` preprocessor to a HistGradientBoosting estimator.
 
-        Only HistGradientBoosting estimators can consume the native categorical
-        and NaN handling; anything else is a misuse and is rejected here (the
-        single place every pipeline is built). Side effect: the cloned estimator
-        gets ``categorical_features="from_dtype"`` so pandas ``category`` columns
-        produced by the native preprocessor are split on directly.
+        Only HistGradientBoosting estimators (and ensembles thereof, whose
+        members are validated when their own pipelines are built) can consume
+        the native categorical and NaN handling; anything else is a misuse and
+        is rejected here (the single place every pipeline is built). Side
+        effect: the cloned estimator gets ``categorical_features="from_dtype"``
+        so pandas ``category`` columns produced by the native preprocessor are
+        split on directly.
         """
+        if isinstance(
+            estimator,
+            (VotingClassifier, StackingClassifier, VotingRegressor, StackingRegressor),
+        ):
+            return
         if not isinstance(
             estimator,
             (HistGradientBoostingClassifier, HistGradientBoostingRegressor),
@@ -1009,7 +1038,9 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         return Pipeline([("initial_preprocessor", preprocessor), step], memory=self._memory)
 
     def add_estimators(
-        self, estimators: dict[str, ClassifierMixin] | Sequence[ClassifierMixin]
+        self,
+        estimators: dict[str, ClassifierMixin] | Sequence[ClassifierMixin],
+        include_preprocessor: bool | None = None,
     ) -> PoniardBaseEstimator:
         """Include new estimator. This is the recommended way of adding an estimator (as opposed
         to modifying `pipelines` directly), since it also injects random state, n_jobs
@@ -1019,6 +1050,10 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         ----------
         estimators :
             Estimators to add.
+        include_preprocessor :
+            Forwarded to `_make_pipeline`. ``None`` (default) resolves from
+            ``self.preprocess``; ``False`` adds the estimator bare (used by
+            mixed-preprocessor ensembles whose members already preprocess).
 
         Returns
         -------
@@ -1046,7 +1081,9 @@ class PoniardBaseEstimator(ResultsMixin, EnsembleMixin, TuningMixin, ABC):
         ]
         self.pipelines.update(
             {
-                name: self._make_pipeline(name, estimator)
+                name: self._make_pipeline(
+                    name, estimator, include_preprocessor=include_preprocessor
+                )
                 for name, estimator in new_estimators.items()
             }
         )

--- a/poniard/estimators/ensemble.py
+++ b/poniard/estimators/ensemble.py
@@ -78,7 +78,7 @@ class EnsembleMixin:
             raise ValueError("Strategy must be either 'diversity' or 'top_n'.")
         estimator_names = element_to_list_maybe(estimator_names)
         if estimator_names:
-            models = [(name, self.pipelines[name]._final_estimator) for name in estimator_names]
+            selected = list(estimator_names)
         elif strategy == "diversity" and X is not None and y is not None:
             selected = self._select_diverse(
                 top_n=top_n or 3,
@@ -87,7 +87,6 @@ class EnsembleMixin:
                 X=X,
                 y=y,
             )
-            models = [(name, self.pipelines[name]._final_estimator) for name in selected]
         else:
             if sort_by:
                 sorter = sort_by
@@ -99,7 +98,19 @@ class EnsembleMixin:
                 for name in self._means.sort_values(sorter, ascending=False).index
                 if name not in dummy
             ]
-            models = [(name, self.pipelines[name]._final_estimator) for name in eligible[:top_n]]
+            selected = eligible[:top_n]
+
+        # If every member maps to the same preprocessor, wrap the ensemble in it
+        # and pass bare estimators (preprocessing runs once). If members are
+        # mixed, each member carries its own full pipeline and the ensemble has
+        # no outer preprocessor.
+        member_preps = [self.preprocessor_map.get(name, "default") for name in selected]
+        same_preprocessor = len(set(member_preps)) == 1
+        if same_preprocessor:
+            models = [(name, self.pipelines[name]._final_estimator) for name in selected]
+        else:
+            models = [(name, self.pipelines[name]) for name in selected]
+
         if method == "voting":
             if self.poniard_task == "classification":
                 ensemble = VotingClassifier(estimators=models, verbose=self.verbose, **kwargs)
@@ -115,7 +126,11 @@ class EnsembleMixin:
                     estimators=models, verbose=self.verbose, cv=self.cv, **kwargs
                 )
         ensemble_name = ensemble_name or ensemble.__class__.__name__
-        self.add_estimators(estimators={ensemble_name: ensemble})
+        if same_preprocessor and self.preprocess:
+            self.preprocessor_map[ensemble_name] = member_preps[0]
+            self.add_estimators(estimators={ensemble_name: ensemble})
+        else:
+            self.add_estimators(estimators={ensemble_name: ensemble}, include_preprocessor=False)
         return self
 
     def _select_diverse(

--- a/tests/test_preprocessor_map.py
+++ b/tests/test_preprocessor_map.py
@@ -307,3 +307,70 @@ def test_tuning_with_native_pipeline(X_y):
         grid={"HistGradientBoostingClassifier__learning_rate": [0.01, 0.1]},
     )
     assert "HistGradientBoostingClassifier_tuned" in clf.pipelines
+
+
+def test_ensemble_all_default_uses_default_preprocessor(X_y):
+    X, y = X_y
+    clf = PoniardClassifier(
+        estimators=[LogisticRegression(), LogisticRegression(max_iter=1000)],
+        cv=2,
+        random_state=0,
+    )
+    clf.fit(X, y, show_info=False)
+    clf.build_ensemble(
+        method="voting",
+        voting="soft",
+        estimator_names=["LogisticRegression", "LogisticRegression_2"],
+    )
+    pipe = clf.pipelines["VotingClassifier"]
+    assert "preprocessor" in [s for s, _ in pipe.steps]
+    assert pipe.named_steps["preprocessor"] is clf.preprocessors["default"]
+    assert clf.preprocessor_map["VotingClassifier"] == "default"
+    members = pipe.named_steps["VotingClassifier"].estimators
+    assert all(not hasattr(m, "steps") for _, m in members)
+
+
+def test_ensemble_all_native_uses_native_preprocessor(X_y):
+    X, y = X_y
+    clf = PoniardClassifier(
+        estimators={
+            "hgb1": HistGradientBoostingClassifier(max_iter=50, random_state=0),
+            "hgb2": HistGradientBoostingClassifier(max_iter=50, random_state=1),
+        },
+        cv=2,
+        random_state=0,
+        preprocessor_map={"hgb1": "native", "hgb2": "native"},
+    )
+    clf.fit(X, y, show_info=False)
+    clf.build_ensemble(method="voting", voting="soft", estimator_names=["hgb1", "hgb2"])
+    pipe = clf.pipelines["VotingClassifier"]
+    assert pipe.named_steps["preprocessor"] is clf.preprocessors["native"]
+    assert clf.preprocessor_map["VotingClassifier"] == "native"
+    clf.fit(X, y, show_info=False)
+    assert not clf.get_results().isna().any().any()
+
+
+@pytest.mark.parametrize("method", ["voting", "stacking"])
+def test_ensemble_mixed_preprocessors_fits_and_scores(X_y, method):
+    X, y = X_y
+    clf = PoniardClassifier(
+        estimators={
+            "hgb": HistGradientBoostingClassifier(max_iter=50, random_state=0),
+            "lr": LogisticRegression(max_iter=1000),
+        },
+        cv=2,
+        random_state=0,
+        preprocessor_map={"hgb": "native"},
+    )
+    clf.fit(X, y, show_info=False)
+    kwargs = {"voting": "soft"} if method == "voting" else {}
+    clf.build_ensemble(method=method, estimator_names=["hgb", "lr"], **kwargs)
+    name = "VotingClassifier" if method == "voting" else "StackingClassifier"
+    pipe = clf.pipelines[name]
+    assert len(pipe.steps) == 1  # bare, no outer preprocessor
+    members = pipe.named_steps[name].estimators
+    assert all(hasattr(m, "steps") for _, m in members)  # full pipelines
+    clf.fit(X, y, show_info=False)
+    results = clf.get_results()
+    assert name in results.index
+    assert not results.isna().any().any()


### PR DESCRIPTION
## Summary

**Part 2, step 4** (final block) of the ML defaults improvements plan (`docs/ml-defaults-improvements.md`).

### Changes
- `_make_pipeline` gains an `include_preprocessor` knob (`None` = resolve from `self.preprocess`, `False` = bare pipeline); `add_estimators` forwards it.
- `build_ensemble` now inspects the members' `preprocessor_map`:
  - **Same preprocessor** (e.g. all `default` or all `native`): current behavior — bare members, ensemble wrapped in that preprocessor (preprocessing runs once), and the ensemble is mapped to it.
  - **Mixed**: each member contributes its *full pipeline* (sklearn ensembles accept Pipelines) and the ensemble is added bare (no outer preprocessor).
- `_configure_native_estimator` exempts ensembles (Voting/Stacking), whose member estimators were already validated, so an all-native ensemble can be wrapped in the native preprocessor.

### Tests (5 new)
All-default ensemble uses `default` with bare members; all-native ensemble uses `native` and fits/scores; mixed ensemble (voting + stacking, parametrized) is bare with full-pipeline members and fits/scores with no NaNs.

All 276 tests pass; coverage 89.8% (gate 85%); ruff + format clean.